### PR TITLE
chore: enable pre-commit hooks via nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ result-*
 # Editor
 *.swp
 *~
+
+# Pre-Commit Hooks
+.pre-commit-config.yaml

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,12 @@
     };
   };
 
-  outputs = {nixpkgs, ...}: let
+  outputs = {
+    self,
+    nixpkgs,
+    pre-commit-hooks,
+    ...
+  }: let
     systems = [
       "x86_64-linux"
       "aarch64-linux"
@@ -23,7 +28,14 @@
         inherit system;
         config = {};
       };
+      config = {
+        pre-commit = pre-commit-hooks.lib.${system}.run {
+          src = self;
+          hooks = import ./tools/pre-commit.nix {inherit pkgs;};
+        };
+      };
     in rec {
+      checks.pre-commit = config.pre-commit;
       formatter = pkgs.alejandra;
 
       devShells.default = pkgs.mkShell {
@@ -33,8 +45,12 @@
           tokei
           ripgrep
           gh
+          pre-commit
         ];
         shellHook = ''
+          # Generate the .pre-commit-config.yaml symlink when entering the dev shell
+          ${config.pre-commit.shellHook}
+
           echo "Welcome to root dev shell on ${system}!"
         '';
       };
@@ -42,5 +58,6 @@
   in {
     devShells = forEachSystem (system: (createSpace system).devShells);
     formatter = forEachSystem (system: (createSpace system).formatter);
+    checks = forEachSystem (system: (createSpace system).checks);
   };
 }

--- a/tools/pre-commit.nix
+++ b/tools/pre-commit.nix
@@ -1,0 +1,18 @@
+_: {
+  # Nix
+  alejandra.enable = true;
+  deadnix.enable = true;
+  statix.enable = true;
+
+  # Generic file checks
+  check-yaml.enable = true;
+  check-toml.enable = true;
+  check-json.enable = true;
+  check-merge-conflicts.enable = true;
+  end-of-file-fixer.enable = true;
+  trim-trailing-whitespace.enable = true;
+  check-added-large-files = {
+    enable = true;
+    args = ["--maxkb=1000"];
+  };
+}


### PR DESCRIPTION
## Summary

Enables pre-commit hooks via the Nix flake.

Run `nix flake check` to verify, or `nix develop` to install hooks via shellHook.

## Changes

- `flake.nix` — `checks.pre-commit` output, shellHook, `pre-commit` in dev shell
- `tools/pre-commit.nix` — hook definitions
- `.gitignore` — ignores generated `.pre-commit-config.yaml`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #