### PR TITLE
feat: add @scale.digital/astro-bun adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,8 +8,38 @@
         "@biomejs/biome": "2.4.10",
       },
     },
+    "packages/astro-bun": {
+      "name": "@scale.digital/astro-bun",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/bun": "1.3.13",
+        "@types/node": "25.6.0",
+        "typescript": "6.0.2",
+      },
+      "peerDependencies": {
+        "astro": "^6.2.1",
+      },
+    },
   },
   "packages": {
+    "@astrojs/compiler": ["@astrojs/compiler@4.0.0", "", {}, "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA=="],
+
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
+
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA=="],
+
+    "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
+
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.1", "", { "dependencies": { "ci-info": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
@@ -27,5 +57,679 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+
+    "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
+
+    "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@scale.digital/astro-bun": ["@scale.digital/astro-bun@workspace:packages/astro-bun"],
+
+    "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
+
+    "@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "array-iterate": ["array-iterate@2.0.1", "", {}, "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="],
+
+    "astro": ["astro@6.2.1", "", { "dependencies": { "@astrojs/compiler": "^4.0.0", "@astrojs/internal-helpers": "0.9.0", "@astrojs/markdown-remark": "7.1.1", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
+
+    "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@1.2.1", "", {}, "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow=="],
+
+    "fast-string-width": ["fast-string-width@1.1.0", "", { "dependencies": { "fast-string-truncated-width": "^1.2.0" } }, "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.1.6", "", { "dependencies": { "fast-string-width": "^1.1.0" } }, "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
+
+    "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
+
+    "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
+
+    "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
+
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
+    "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
+
+    "is-docker": ["is-docker@4.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+
+    "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
+
+    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
+
+    "p-queue": ["p-queue@9.2.0", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g=="],
+
+    "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
+
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
+    "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
+
+    "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-smartypants": ["remark-smartypants@3.0.2", "", { "dependencies": { "retext": "^9.0.0", "retext-smartypants": "^6.0.0", "unified": "^11.0.4", "unist-util-visit": "^5.0.0" } }, "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "retext": ["retext@9.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "retext-latin": "^4.0.0", "retext-stringify": "^4.0.0", "unified": "^11.0.0" } }, "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA=="],
+
+    "retext-latin": ["retext-latin@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "parse-latin": "^7.0.0", "unified": "^11.0.0" } }, "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA=="],
+
+    "retext-smartypants": ["retext-smartypants@6.2.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ=="],
+
+    "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
+
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
+    "tinyclip": ["tinyclip@0.1.12", "", {}, "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA=="],
+
+    "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
+    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unifont": ["unifont@0.7.4", "", { "dependencies": { "css-tree": "^3.1.0", "ofetch": "^1.5.1", "ohash": "^2.0.11" } }, "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg=="],
+
+    "unist-util-find-after": ["unist-util-find-after@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-modify-children": ["unist-util-modify-children@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "array-iterate": "^2.0.0" } }, "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-children": ["unist-util-visit-children@3.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "unstorage": ["unstorage@1.17.5", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.10", "lru-cache": "^11.2.7", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
+
+    "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@scale.digital/root",
   "private": true,
   "type": "module",
-  "workspaces": [],
+  "workspaces": [
+    "packages/astro-bun"
+  ],
   "scripts": {
     "check": "biome check .",
     "fix": "biome check --write ."

--- a/packages/astro-bun/LICENSE
+++ b/packages/astro-bun/LICENSE
@@ -1,0 +1,58 @@
+BSD 3-Clause License
+
+Copyright (c) 2026, Scaliir Digital UG (haftungsbeschränkt)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+The portions of code in this package that are derived from
+@wyattjoh/astro-bun-adapter are distributed under the MIT License,
+reproduced below. The BSD 3-Clause License above applies to all
+original work, modifications, and the package as a whole.
+
+MIT License
+
+Copyright (c) 2025 Wyatt Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/astro-bun/README.md
+++ b/packages/astro-bun/README.md
@@ -1,0 +1,174 @@
+# @scale.digital/astro-bun
+
+A native Bun adapter for Astro 6 — runs SSR, hybrid, and static sites directly on `Bun.serve`.
+
+> **Status: pre-1.0**
+>
+> This adapter is in active development and is used in production by Scaliir Digital.
+>
+> Currently validated with Astro 6.2.0 using the Qwik Astro integration:
+>
+> - `astro` 6.2.0
+> - `@qwik.dev/astro` 1.0.1
+> - `@qwik.dev/core` 2.0.0-beta.32
+>
+> Other Astro setups may work, but have not been validated yet.
+> The public API may change in minor versions until 1.0.
+
+## Features
+
+- **Bun-native startup path.** Runs directly on Bun via `Bun.serve`.
+- **Zero runtime dependencies.** Only adapter code and Astro runtime helpers.
+- **Compression.** Build-time Brotli/gzip for static assets.
+- **First-class caching.** Persistent Stale-While-Revalidate (SWR) cache with request coalescing for SSR routes.
+
+## Installation
+
+```sh
+bun add @scale.digital/astro-bun
+```
+
+Requirements:
+
+- Astro `^6.0.0`
+- Bun `>=1.3.0`
+
+Astro itself uses Node tooling at build time. Node `>=22.12` is required for `astro build`. The runtime is Bun-only.
+
+## Quick start
+
+```ts
+// astro.config.ts
+import { defineConfig } from 'astro/config';
+import bun from '@scale.digital/astro-bun';
+
+export default defineConfig({
+  output: 'server',
+  adapter: bun(),
+});
+```
+
+Build and run:
+
+```sh
+bun run build
+bun run ./dist/server/index.mjs
+```
+
+The server will start on `PORT` (default `4321`) and `HOST` (default `0.0.0.0`).
+
+## Configuration
+
+All options are optional.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `cache` | `boolean \| CacheOptions` | `false` | Enable the Stale-While-Revalidate response cache. Pass `true` for defaults, or an object to customize. |
+| `compress` | `boolean` | `true` | Generate Brotli and gzip versions of static assets at build time. |
+| `staticCacheControl` | `string` | `public, max-age=86400, must-revalidate` | `Cache-Control` header for non-hashed static assets. |
+
+### Compression
+
+When `compress: true` (the default), the adapter generates `.br` and `.gz` versions of compressible static assets (`.css`, `.js`, `.html`, `.svg`, `.json`, `.xml`, `.txt`, `.mjs`) during `astro build`. At request time, the server reads the `Accept-Encoding` header and serves the matching pre-compressed file when available, falling back to the original.
+
+Set `compress: false` to skip this step if you handle compression elsewhere (e.g. a custom build pipeline) or if the additional build time is a concern.
+
+### `CacheOptions`
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `maxByteSize` | `number` | `104857600` (100 MB) | Maximum on-disk size of the cache. Oldest entries are evicted when the limit is reached. |
+| `cacheDir` | `string` | OS temp dir | Directory where cache files are stored. |
+| `warmOnInit` | `boolean` | `true` | Read the cache index on server start. Set `false` for faster startup at the cost of an empty cache on first request. |
+
+### Example
+
+```ts
+import { defineConfig } from 'astro/config';
+import bun from '@scale.digital/astro-bun';
+
+export default defineConfig({
+  output: 'server',
+  adapter: bun({
+    cache: {
+      maxByteSize: 500 * 1024 * 1024,
+      cacheDir: '/var/cache/astro-bun',
+      warmOnInit: false,
+    },
+    staticCacheControl: 'public, max-age=3600, must-revalidate',
+  }),
+});
+```
+
+## Caching
+
+The cache is opt-in and applies only to SSR responses that explicitly opt in via `Cache-Control: s-maxage=N`. Static assets are served from disk with their own `Cache-Control` (see `staticCacheControl`).
+
+### How it works
+
+1. A request hits an SSR route.
+2. If a cached response exists and is fresh, it is served immediately (`x-astro-cache: HIT`).
+3. If a cached response exists but is stale (past `s-maxage`, within `stale-while-revalidate`), the stale response is served (`x-astro-cache: STALE`) and a background revalidation is triggered.
+4. If no cached response exists, the route is rendered, stored, and served (`x-astro-cache: MISS`).
+5. Concurrent misses for the same path are coalesced — only one render runs.
+
+### Response header: `x-astro-cache`
+
+| Value | Meaning |
+| --- | --- |
+| `HIT` | Fresh cached response served. |
+| `STALE` | Stale cached response served; background revalidation in progress. |
+| `MISS` | No cache entry; response was rendered and stored. |
+| `BYPASS` | Route opted out of caching (no `s-maxage` directive). |
+| `STATIC` | Static asset served from disk; cache not applicable. |
+
+### Opting routes into the cache
+
+Set `Cache-Control` in your Astro route or middleware:
+
+```ts
+// src/pages/blog/[slug].astro
+Astro.response.headers.set(
+  'Cache-Control',
+  'public, s-maxage=60, stale-while-revalidate=600'
+);
+```
+
+Routes without `s-maxage` are passed through and tagged `BYPASS`.
+
+## Cache invalidation
+
+Two functions are exposed for on-demand invalidation:
+
+```ts
+import { expireAll, expirePath } from '@scale.digital/astro-bun/cache';
+
+// Invalidate a single path
+await expirePath('/blog/my-post');
+
+// Invalidate the entire cache
+await expireAll();
+```
+
+Both functions are safe to call when the cache is disabled — they become no-ops.
+
+Typical use: call `expirePath` from a webhook after content updates in a CMS.
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `4321` | Port the server listens on. |
+| `HOST` | `0.0.0.0` | Hostname or IP the server binds to. |
+
+## Acknowledgements
+
+This adapter is based on [`@wyattjoh/astro-bun-adapter`](https://github.com/wyattjoh/astro-bun-adapter) by Wyatt Johnson. It preserves the goal of running Astro on Bun and follows the upstream ISR caching model, including LRU caching, disk persistence, stale-while-revalidate behavior, image-endpoint cache overrides, and build namespacing.
+
+This fork is a Bun-native rewrite with no external runtime dependencies and adds build-time Brotli and gzip compression.
+
+The upstream adapter was itself inspired by [`astro-bun-adapter`](https://github.com/ido-pluto/astro-bun-adapter) by Ido Pluto.
+
+## License
+
+[BSD-3-Clause](./LICENSE). Portions derived from `@wyattjoh/astro-bun-adapter` remain under their original MIT license; see [LICENSE](./LICENSE) for the full text.

--- a/packages/astro-bun/package.json
+++ b/packages/astro-bun/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@scale.digital/astro-bun",
+  "version": "0.0.1",
+  "description": "A native Bun adapter for Astro 6 — runs SSR, hybrid, and static sites directly on Bun.serve",
+  "keywords": [
+    "astro",
+    "astro-integration",
+    "astro-adapter",
+    "bun",
+    "ssr",
+    "cache",
+    "isr",
+    "swr",
+    "compression",
+    "brotli",
+    "gzip"
+  ],
+  "homepage": "https://github.com/ScaliirDigital/root/tree/main/packages/astro-bun#readme",
+  "bugs": {
+    "url": "https://github.com/ScaliirDigital/root/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ScaliirDigital/root.git",
+    "directory": "packages/astro-bun"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Scaliir Digital UG (haftungsbeschränkt)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./cache": {
+      "types": "./dist/cache/index.d.ts",
+      "default": "./dist/cache/index.js"
+    },
+    "./server.js": "./dist/server.js",
+    "./preview": "./dist/preview.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "bun": ">=1.3.0"
+  },
+  "scripts": {
+    "build": "bun build ./src/index.ts ./src/server.ts ./src/preview.ts ./src/cache --outdir ./dist --target bun --external 'virtual:@scale.digital/astro-bun/config' --external astro",
+    "types": "tsc -p tsconfig.build.json",
+    "prepack": "bun run build && bun run types"
+  },
+  "peerDependencies": {
+    "astro": "^6.2.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.13",
+    "@types/node": "25.6.0",
+    "typescript": "6.0.2"
+  }
+}

--- a/packages/astro-bun/src/cache/images.ts
+++ b/packages/astro-bun/src/cache/images.ts
@@ -1,0 +1,37 @@
+/**
+ * Astro image-endpoint query parameters that affect the rendered output.
+ * Other parameters (e.g. cache busters, tracking IDs) are stripped from
+ * the cache key so semantically equivalent requests share an entry.
+ *
+ * @see https://docs.astro.build/en/guides/images/
+ */
+const IMAGE_PARAMS = [
+  'background',
+  'f',
+  'fit',
+  'h',
+  'href',
+  'position',
+  'q',
+  'w',
+];
+
+/**
+ * Build a normalized cache key for an Astro image endpoint request.
+ *
+ * Filters the URL search params down to the ones Astro actually uses
+ * for image transformation, so unrelated query params don't fragment
+ * the cache.
+ */
+export function buildImageCacheKey(
+  pathname: string,
+  params: URLSearchParams,
+): string {
+  const normalized = new URLSearchParams();
+  for (const key of IMAGE_PARAMS) {
+    const value = params.get(key);
+    if (value !== null) normalized.set(key, value);
+  }
+  const qs = normalized.toString();
+  return qs ? `${pathname}?${qs}` : pathname;
+}

--- a/packages/astro-bun/src/cache/index.ts
+++ b/packages/astro-bun/src/cache/index.ts
@@ -1,0 +1,50 @@
+import type { CacheControl } from '../types.ts';
+
+const CACHE_KEY = Symbol.for('@scale.digital/astro-bun:cache');
+
+/** Register the cache control instance on globalThis for cross-module access. */
+export function registerCache(instance: CacheControl): void {
+  (globalThis as Record<symbol, unknown>)[CACHE_KEY] = instance;
+}
+
+function getCache(): CacheControl | undefined {
+  return (globalThis as Record<symbol, unknown>)[CACHE_KEY] as
+    | CacheControl
+    | undefined;
+}
+
+/**
+ * Expire a cache entry by pathname. The entry is deleted and will be
+ * re-rendered on the next request (lazy revalidation).
+ *
+ * No-op when caching is not enabled — safe to call unconditionally.
+ *
+ * @example
+ * ```ts
+ * import { unstable_expirePath } from "@scale.digital/astro-bun/cache";
+ * await unstable_expirePath("/blog/my-post");
+ * ```
+ */
+export async function unstable_expirePath(pathname: string): Promise<void> {
+  const cache = getCache();
+  if (!cache) return;
+  await cache.expire(pathname);
+}
+
+/**
+ * Expire all cache entries. Every cached page is deleted and will be
+ * re-rendered on the next request (lazy revalidation).
+ *
+ * No-op when caching is not enabled — safe to call unconditionally.
+ *
+ * @example
+ * ```ts
+ * import { unstable_expireAll } from "@scale.digital/astro-bun/cache";
+ * await unstable_expireAll();
+ * ```
+ */
+export async function unstable_expireAll(): Promise<void> {
+  const cache = getCache();
+  if (!cache) return;
+  await cache.expireAll();
+}

--- a/packages/astro-bun/src/cache/serve.test.ts
+++ b/packages/astro-bun/src/cache/serve.test.ts
@@ -1,0 +1,728 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { buildImageCacheKey } from './images.ts';
+import { __test__, createCacheServer } from './serve.ts';
+import type { Clock, FileSystem, StoreDeps } from './store.ts';
+
+// ═════════════════════════════════════════════════════════════════════════
+// Test helpers (fake clock + fake fs, same shape as store.test.ts)
+// ═════════════════════════════════════════════════════════════════════════
+
+function createFakeFileSystem(): FileSystem {
+  const files = new Map<string, string>();
+  return {
+    async read(path) {
+      return files.get(path);
+    },
+    async write(path, data) {
+      files.set(path, data);
+    },
+    async remove(path) {
+      files.delete(path);
+    },
+    async exists(path) {
+      return files.has(path);
+    },
+    async mkdir() {},
+    async removeDir(path) {
+      const prefix = path.endsWith('/') ? path : `${path}/`;
+      for (const f of [...files.keys()]) {
+        if (f === path || f.startsWith(prefix)) files.delete(f);
+      }
+    },
+  };
+}
+
+type FakeClock = Clock & {
+  setNow: (ms: number) => void;
+  advance: (ms: number) => void;
+};
+
+function createFakeClock(initialNow = 1_000_000): FakeClock {
+  let now = initialNow;
+  type T = { dueAt: number; fn: () => void; cleared: boolean };
+  const timers: T[] = [];
+  return {
+    now: () => now,
+    setTimeout(fn, ms) {
+      const t: T = { dueAt: now + ms, fn, cleared: false };
+      timers.push(t);
+      return {
+        clear() {
+          t.cleared = true;
+        },
+      };
+    },
+    setNow(ms) {
+      now = ms;
+    },
+    advance(ms) {
+      const target = now + ms;
+      while (true) {
+        const due = timers
+          .filter((t) => !t.cleared && t.dueAt <= target)
+          .sort((a, b) => a.dueAt - b.dueAt)[0];
+        if (!due) break;
+        now = due.dueAt;
+        due.cleared = true;
+        due.fn();
+      }
+      now = target;
+    },
+  };
+}
+
+function fakeDeps(initialNow?: number): StoreDeps & { clock: FakeClock } {
+  return {
+    fs: createFakeFileSystem(),
+    clock: createFakeClock(initialNow),
+    hash: (k) => `h_${k}`,
+  };
+}
+
+const BUILD_ID = 'b1';
+const CACHE_DIR = '/cache';
+const IMAGE_ROUTE = '/_image';
+
+function req(path: string) {
+  return new Request(`http://localhost${path}`);
+}
+
+function makeOrigin(
+  headers: Record<string, string> = {},
+  body = 'ok',
+  status = 200,
+) {
+  return mock(async (_request: Request) => {
+    return new Response(body, { status, headers });
+  });
+}
+
+function makeServer(
+  origin: (r: Request) => Promise<Response>,
+  deps = fakeDeps(),
+) {
+  return {
+    server: createCacheServer(
+      {
+        origin,
+        maxByteSize: 1024 * 1024,
+        cacheDir: CACHE_DIR,
+        buildId: BUILD_ID,
+        warmOnInit: false,
+        imageEndpointRoute: IMAGE_ROUTE,
+      },
+      deps,
+    ),
+    deps,
+  };
+}
+
+describe('Cache', () => {
+  describe('parseDirective', () => {
+    test('extracts s-maxage from compound header', () => {
+      expect(__test__.parseDirective('public, s-maxage=60', 's-maxage')).toBe(
+        60,
+      );
+    });
+
+    test('extracts stale-while-revalidate', () => {
+      expect(
+        __test__.parseDirective(
+          's-maxage=60, stale-while-revalidate=300',
+          'stale-while-revalidate',
+        ),
+      ).toBe(300);
+    });
+
+    test('case-insensitive', () => {
+      expect(__test__.parseDirective('S-MAXAGE=42', 's-maxage')).toBe(42);
+    });
+
+    test('returns undefined when directive absent', () => {
+      expect(
+        __test__.parseDirective('public, max-age=60', 's-maxage'),
+      ).toBeUndefined();
+    });
+
+    test('handles whitespace around equals', () => {
+      expect(__test__.parseDirective('s-maxage = 60', 's-maxage')).toBe(60);
+    });
+
+    test('returns undefined for empty header', () => {
+      expect(__test__.parseDirective('', 's-maxage')).toBeUndefined();
+    });
+  });
+
+  describe('extractCacheableEntry', () => {
+    test('returns entry when s-maxage present', () => {
+      const entry = __test__.extractCacheableEntry(
+        [['cache-control', 's-maxage=60']],
+        200,
+        new Uint8Array([1, 2]),
+        12345,
+      );
+      expect(entry).toBeDefined();
+      expect(entry?.sMaxAge).toBe(60);
+      expect(entry?.swr).toBe(0);
+      expect(entry?.cachedAt).toBe(12345);
+      expect(entry?.status).toBe(200);
+    });
+
+    test('captures stale-while-revalidate', () => {
+      const entry = __test__.extractCacheableEntry(
+        [['cache-control', 's-maxage=60, stale-while-revalidate=120']],
+        200,
+        new Uint8Array(),
+        0,
+      );
+      expect(entry?.swr).toBe(120);
+    });
+
+    test('returns undefined without s-maxage', () => {
+      const entry = __test__.extractCacheableEntry(
+        [['cache-control', 'max-age=60']],
+        200,
+        new Uint8Array(),
+        0,
+      );
+      expect(entry).toBeUndefined();
+    });
+
+    test('returns undefined when s-maxage=0', () => {
+      const entry = __test__.extractCacheableEntry(
+        [['cache-control', 's-maxage=0']],
+        200,
+        new Uint8Array(),
+        0,
+      );
+      expect(entry).toBeUndefined();
+    });
+
+    test('returns undefined when no cache-control header at all', () => {
+      const entry = __test__.extractCacheableEntry(
+        [['content-type', 'text/html']],
+        200,
+        new Uint8Array(),
+        0,
+      );
+      expect(entry).toBeUndefined();
+    });
+  });
+
+  describe('Image Endpoint Helpers', () => {
+    describe('isImageEndpointKey', () => {
+      test('exact route matches', () => {
+        expect(__test__.isImageEndpointKey('/_image', '/_image')).toBe(true);
+      });
+
+      test('route with query string matches', () => {
+        expect(
+          __test__.isImageEndpointKey('/_image?href=foo.png', '/_image'),
+        ).toBe(true);
+      });
+
+      test('different route does not match', () => {
+        expect(__test__.isImageEndpointKey('/page', '/_image')).toBe(false);
+      });
+
+      test('route prefix without ? does not match', () => {
+        expect(__test__.isImageEndpointKey('/_imagery', '/_image')).toBe(false);
+      });
+    });
+
+    describe('overrideImageCacheControl', () => {
+      test('replaces existing cache-control header in place', () => {
+        const headers: [string, string][] = [
+          ['content-type', 'image/png'],
+          ['cache-control', 'public, max-age=31536000'],
+        ];
+        __test__.overrideImageCacheControl(headers);
+        expect(headers[1]?.[1]).toContain('s-maxage=31536000');
+        expect(headers[1]?.[1]).toContain('stale-while-revalidate');
+      });
+
+      test('no-op when cache-control header absent', () => {
+        const headers: [string, string][] = [['content-type', 'image/png']];
+        __test__.overrideImageCacheControl(headers);
+        expect(headers).toEqual([['content-type', 'image/png']]);
+      });
+    });
+
+    describe('buildImageCacheKey', () => {
+      test('returns pathname unchanged when no params are present', () => {
+        const params = new URLSearchParams();
+        expect(buildImageCacheKey('/_image', params)).toBe('/_image');
+      });
+
+      test('returns pathname unchanged when no recognized params are present', () => {
+        const params = new URLSearchParams('utm_source=newsletter&fbclid=123');
+        expect(buildImageCacheKey('/_image', params)).toBe('/_image');
+      });
+
+      test('includes only the recognized params that are actually set', () => {
+        const params = new URLSearchParams('href=foo.png&w=200&q=80');
+        const key = buildImageCacheKey('/_image', params);
+        expect(key).toBe('/_image?href=foo.png&q=80&w=200');
+      });
+
+      test('strips unrecognized params while keeping recognized ones', () => {
+        const params = new URLSearchParams(
+          'href=foo.png&w=200&utm_source=newsletter&fbclid=123',
+        );
+        const key = buildImageCacheKey('/_image', params);
+        expect(key).toBe('/_image?href=foo.png&w=200');
+      });
+
+      test('produces identical keys regardless of input param order', () => {
+        const a = new URLSearchParams('w=200&href=foo.png&q=80');
+        const b = new URLSearchParams('q=80&href=foo.png&w=200');
+        expect(buildImageCacheKey('/_image', a)).toBe(
+          buildImageCacheKey('/_image', b),
+        );
+      });
+
+      test('treats different param values as different keys', () => {
+        const a = new URLSearchParams('href=foo.png&w=200');
+        const b = new URLSearchParams('href=foo.png&w=400');
+        expect(buildImageCacheKey('/_image', a)).not.toBe(
+          buildImageCacheKey('/_image', b),
+        );
+      });
+
+      test('captures all supported image params when set', () => {
+        const params = new URLSearchParams({
+          background: '#fff',
+          f: 'webp',
+          fit: 'cover',
+          h: '100',
+          href: 'foo.png',
+          position: 'center',
+          q: '80',
+          w: '200',
+        });
+        const key = buildImageCacheKey('/_image', params);
+        expect(key).toContain('background=%23fff');
+        expect(key).toContain('f=webp');
+        expect(key).toContain('fit=cover');
+        expect(key).toContain('h=100');
+        expect(key).toContain('href=foo.png');
+        expect(key).toContain('position=center');
+        expect(key).toContain('q=80');
+        expect(key).toContain('w=200');
+      });
+
+      test('uses the provided pathname unchanged in the key', () => {
+        const params = new URLSearchParams('href=foo.png');
+        expect(buildImageCacheKey('/custom-route', params)).toBe(
+          '/custom-route?href=foo.png',
+        );
+      });
+
+      test('preserves empty string values when params are explicitly set to empty', () => {
+        const params = new URLSearchParams('href=foo.png&w=');
+        const key = buildImageCacheKey('/_image', params);
+        expect(key).toBe('/_image?href=foo.png&w=');
+      });
+    });
+  });
+
+  describe('classifyEntry', () => {
+    const baseEntry = {
+      body: new Uint8Array(),
+      headers: [],
+      status: 200,
+      cachedAt: 1000,
+      sMaxAge: 60,
+      swr: 30,
+    };
+
+    test('miss when entry undefined', () => {
+      expect(__test__.classifyEntry(undefined, 0)).toEqual({ status: 'miss' });
+    });
+
+    test('hit when within s-maxage window', () => {
+      const decision = __test__.classifyEntry(baseEntry, 1000 + 30_000);
+      expect(decision.status).toBe('hit');
+    });
+
+    test('hit at exact cachedAt', () => {
+      const decision = __test__.classifyEntry(baseEntry, 1000);
+      expect(decision.status).toBe('hit');
+    });
+
+    test('stale when past s-maxage but within SWR', () => {
+      // 60s fresh, 30s swr → stale at 61s, expired at 91s
+      const decision = __test__.classifyEntry(baseEntry, 1000 + 61_000);
+      expect(decision.status).toBe('stale');
+    });
+
+    test('expired when beyond s-maxage + swr', () => {
+      const decision = __test__.classifyEntry(baseEntry, 1000 + 100_000);
+      expect(decision.status).toBe('expired');
+    });
+
+    test('expired when swr is 0 and past s-maxage', () => {
+      const noSwr = { ...baseEntry, swr: 0 };
+      const decision = __test__.classifyEntry(noSwr, 1000 + 61_000);
+      expect(decision.status).toBe('expired');
+    });
+  });
+
+  describe('responseFromEntry', () => {
+    test('reconstructs response with cache header', async () => {
+      const res = __test__.responseFromEntry(
+        {
+          body: new Uint8Array([104, 105]), // "hi"
+          headers: [['content-type', 'text/plain']],
+          status: 201,
+          cachedAt: 0,
+          sMaxAge: 60,
+          swr: 0,
+        },
+        'HIT',
+      );
+      expect(res.status).toBe(201);
+      expect(res.headers.get('content-type')).toBe('text/plain');
+      expect(res.headers.get('x-astro-cache')).toBe('HIT');
+      expect(await res.text()).toBe('hi');
+    });
+  });
+
+  describe('Server > Basic Flow', () => {
+    test('cache miss — calls origin, returns SSR response', async () => {
+      const origin = makeOrigin();
+      const { server } = makeServer(origin);
+      const res = await server(req('/page'), '/page');
+      expect(origin).toHaveBeenCalledTimes(1);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('x-astro-cache')).toBe('MISS');
+      expect(await res.text()).toBe('ok');
+    });
+
+    test('fresh hit — second request served from cache', async () => {
+      const origin = makeOrigin({ 'cache-control': 's-maxage=60' }, 'cached');
+      const { server } = makeServer(origin);
+      const first = await server(req('/page'), '/page');
+      await first.text(); // drain → entry populated
+
+      const second = await server(req('/page'), '/page');
+      expect(origin).toHaveBeenCalledTimes(1);
+      expect(second.headers.get('x-astro-cache')).toBe('HIT');
+      expect(await second.text()).toBe('cached');
+    });
+
+    test('non-cacheable response (no s-maxage) — never cached', async () => {
+      const origin = makeOrigin({ 'cache-control': 'max-age=60' }, 'nope');
+      const { server } = makeServer(origin);
+      await (await server(req('/page'), '/page')).text();
+      await (await server(req('/page'), '/page')).text();
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+
+    test('s-maxage=0 — not cached', async () => {
+      const origin = makeOrigin({ 'cache-control': 's-maxage=0' }, 'zero');
+      const { server } = makeServer(origin);
+      await (await server(req('/page'), '/page')).text();
+      await (await server(req('/page'), '/page')).text();
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Server > Stale-While-Revalidate', () => {
+    test('serves stale + triggers background revalidation', async () => {
+      let n = 0;
+      const origin = mock(async (_r: Request) => {
+        n++;
+        return new Response(`v${n}`, {
+          status: 200,
+          headers: {
+            'cache-control': 's-maxage=60, stale-while-revalidate=600',
+          },
+        });
+      });
+      const deps = fakeDeps(1_000_000);
+      const { server } = makeServer(origin, deps);
+
+      await (await server(req('/page'), '/page')).text();
+      expect(origin).toHaveBeenCalledTimes(1);
+
+      // Move into SWR window: past s-maxage (60s) but within swr (600s)
+      deps.clock.advance(61_000);
+
+      const stale = await server(req('/page'), '/page');
+      expect(stale.headers.get('x-astro-cache')).toBe('STALE');
+      expect(await stale.text()).toBe('v1');
+      expect(origin).toHaveBeenCalledTimes(2); // background fired
+
+      // Allow microtasks to settle so revalidation finishes writing.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Subsequent request: cached entry was rewritten with cachedAt=now,
+      // so it's a fresh HIT.
+      const fresh = await server(req('/page'), '/page');
+      expect(fresh.headers.get('x-astro-cache')).toBe('HIT');
+      expect(await fresh.text()).toBe('v2');
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+
+    test('concurrent stale requests deduplicate revalidation', async () => {
+      let n = 0;
+      const origin = mock(async (_r: Request) => {
+        n++;
+        return new Response(`v${n}`, {
+          status: 200,
+          headers: {
+            'cache-control': 's-maxage=60, stale-while-revalidate=600',
+          },
+        });
+      });
+      const deps = fakeDeps(1_000_000);
+      const { server } = makeServer(origin, deps);
+
+      await (await server(req('/page'), '/page')).text();
+      deps.clock.advance(61_000);
+
+      await Promise.all([
+        server(req('/page'), '/page').then((r) => r.text()),
+        server(req('/page'), '/page').then((r) => r.text()),
+        server(req('/page'), '/page').then((r) => r.text()),
+      ]);
+
+      // 1 initial + 1 background revalidation.
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+
+    test('expired beyond SWR — full re-render and replaces entry', async () => {
+      let n = 0;
+      const origin = mock(async (_r: Request) => {
+        n++;
+        return new Response(`v${n}`, {
+          status: 200,
+          headers: {
+            'cache-control': 's-maxage=60, stale-while-revalidate=30',
+          },
+        });
+      });
+      const deps = fakeDeps(1_000_000);
+      const { server } = makeServer(origin, deps);
+
+      await (await server(req('/page'), '/page')).text();
+      deps.clock.advance(91_000); // past s-maxage(60) + swr(30) = 90s
+
+      const res = await server(req('/page'), '/page');
+      expect(res.headers.get('x-astro-cache')).toBe('MISS');
+      expect(await res.text()).toBe('v2');
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+
+    test('background revalidation rejection is swallowed', async () => {
+      let n = 0;
+      const origin = mock((_r: Request) => {
+        n++;
+        // First call (initial populate) succeeds; second (revalidation) rejects.
+        if (n === 2) return Promise.reject(new Error('revalidation boom'));
+        return Promise.resolve(
+          new Response('v1', {
+            status: 200,
+            headers: {
+              'cache-control': 's-maxage=60, stale-while-revalidate=600',
+            },
+          }),
+        );
+      });
+      const deps = fakeDeps(1_000_000);
+      const { server } = makeServer(origin, deps);
+
+      await (await server(req('/page'), '/page')).text();
+      deps.clock.advance(61_000); // into SWR window
+
+      // Should not throw despite the failing revalidation
+      const stale = await server(req('/page'), '/page');
+      expect(stale.headers.get('x-astro-cache')).toBe('STALE');
+      expect(await stale.text()).toBe('v1');
+
+      // Allow the rejection to surface and the .catch to swallow it.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // The cached entry is still serveable as stale (revalidation failed silently).
+      const stillStale = await server(req('/page'), '/page');
+      expect(stillStale.headers.get('x-astro-cache')).toBe('STALE');
+    });
+  });
+
+  describe('Server > Concurrent Request Coalescing', () => {
+    test('concurrent miss for same key — one origin call, both get response', async () => {
+      let n = 0;
+      const origin = mock(async (_r: Request) => {
+        n++;
+        return new Response(`v${n}`, {
+          status: 200,
+          headers: { 'cache-control': 's-maxage=60' },
+        });
+      });
+      const { server } = makeServer(origin);
+
+      const [a, b] = await Promise.all([
+        server(req('/page'), '/page'),
+        server(req('/page'), '/page'),
+      ]);
+
+      expect(origin).toHaveBeenCalledTimes(1);
+      expect(await a.text()).toBe('v1');
+      expect(await b.text()).toBe('v1');
+    });
+
+    test('concurrent miss for non-cacheable — second falls back to BYPASS', async () => {
+      let n = 0;
+      const origin = mock(async (_r: Request) => {
+        n++;
+        // small delay so both gets land before first response is processed
+        await new Promise((r) => setImmediate(r));
+        return new Response(`v${n}`, {
+          status: 200,
+          headers: { 'cache-control': 'max-age=60' },
+        });
+      });
+      const { server } = makeServer(origin);
+
+      const [a, b] = await Promise.all([
+        server(req('/page'), '/page'),
+        server(req('/page'), '/page'),
+      ]);
+
+      const aText = await a.text();
+      const bText = await b.text();
+      expect(aText).toMatch(/v\d/);
+      expect(bText).toMatch(/v\d/);
+      // Second caller waits for first then sees not-cacheable result → BYPASS.
+      const statuses = [
+        a.headers.get('x-astro-cache'),
+        b.headers.get('x-astro-cache'),
+      ];
+      expect(statuses).toContain('MISS');
+      expect(statuses).toContain('BYPASS');
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Server > Image Endpoint', () => {
+    test('image with only max-age gets overridden and cached', async () => {
+      const origin = makeOrigin(
+        { 'cache-control': 'public, max-age=31536000' },
+        'png-bytes',
+      );
+      const { server } = makeServer(origin);
+      const key = '/_image?href=foo.png&w=100';
+
+      await (await server(req(key), key)).text();
+      const second = await server(req(key), key);
+      expect(origin).toHaveBeenCalledTimes(1);
+      expect(second.headers.get('x-astro-cache')).toBe('HIT');
+      expect(await second.text()).toBe('png-bytes');
+    });
+
+    test('non-image with only max-age does NOT get override', async () => {
+      const origin = makeOrigin(
+        { 'cache-control': 'public, max-age=31536000' },
+        'page',
+      );
+      const { server } = makeServer(origin);
+      await (await server(req('/page'), '/page')).text();
+      await (await server(req('/page'), '/page')).text();
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+
+    test('image without any cache-control header — override loop runs but skips', async () => {
+      const origin = makeOrigin({}, 'png');
+      const { server } = makeServer(origin);
+      const key = '/_image?href=foo.png';
+      const res = await server(req(key), key);
+      await res.text();
+      // Not cacheable (no s-maxage, no cache-control at all)
+      expect(origin).toHaveBeenCalledTimes(1);
+    });
+
+    test('different image query strings produce separate entries', async () => {
+      let n = 0;
+      const origin = mock(async (_r: Request) => {
+        n++;
+        return new Response(`img-${n}`, {
+          status: 200,
+          headers: { 'cache-control': 'public, max-age=31536000' },
+        });
+      });
+      const { server } = makeServer(origin);
+
+      const k1 = '/_image?href=a.png&w=100';
+      const k2 = '/_image?href=b.png&w=200';
+      await (await server(req(k1), k1)).text();
+      await (await server(req(k2), k2)).text();
+      expect(origin).toHaveBeenCalledTimes(2);
+
+      const h1 = await server(req(k1), k1);
+      const h2 = await server(req(k2), k2);
+      expect(h1.headers.get('x-astro-cache')).toBe('HIT');
+      expect(h2.headers.get('x-astro-cache')).toBe('HIT');
+      expect(await h1.text()).toBe('img-1');
+      expect(await h2.text()).toBe('img-2');
+      expect(origin).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Server > Control Surface', () => {
+    test('expire(key) removes single entry', async () => {
+      const origin = makeOrigin({ 'cache-control': 's-maxage=60' }, 'page');
+      const { server } = makeServer(origin);
+      await (await server(req('/page'), '/page')).text();
+      expect(
+        (await server(req('/page'), '/page')).headers.get('x-astro-cache'),
+      ).toBe('HIT');
+
+      await server.cache.expire('/page');
+      const after = await server(req('/page'), '/page');
+      expect(after.headers.get('x-astro-cache')).toBe('MISS');
+    });
+
+    test('expireAll clears page entries but preserves image cache', async () => {
+      const origin = mock(async (r: Request) => {
+        const url = new URL(r.url);
+        if (url.pathname === IMAGE_ROUTE) {
+          return new Response('img', {
+            status: 200,
+            headers: { 'cache-control': 'public, max-age=31536000' },
+          });
+        }
+        return new Response('page', {
+          status: 200,
+          headers: { 'cache-control': 's-maxage=60' },
+        });
+      });
+      const { server } = makeServer(origin);
+
+      const imgKey = '/_image?href=x.png';
+      await (await server(req('/page'), '/page')).text();
+      await (await server(req(imgKey), imgKey)).text();
+
+      await server.cache.expireAll();
+
+      expect(
+        (await server(req('/page'), '/page')).headers.get('x-astro-cache'),
+      ).toBe('MISS');
+      expect(
+        (await server(req(imgKey), imgKey)).headers.get('x-astro-cache'),
+      ).toBe('HIT');
+    });
+
+    test('shutdown calls store.save', async () => {
+      const origin = makeOrigin({ 'cache-control': 's-maxage=60' }, 'page');
+      const { server, deps } = makeServer(origin);
+      await (await server(req('/page'), '/page')).text();
+      await server.shutdown();
+      // After shutdown the index file should exist in the fake fs.
+      const indexPath = `${CACHE_DIR}/${BUILD_ID}/index.json`;
+      expect(await deps.fs.read(indexPath)).toBeDefined();
+    });
+  });
+});

--- a/packages/astro-bun/src/cache/serve.ts
+++ b/packages/astro-bun/src/cache/serve.ts
@@ -1,0 +1,271 @@
+import type { CacheControl, CacheEntry, CacheServer } from '../types.ts';
+import { createCacheStore, defaultDeps, type StoreDeps } from './store.ts';
+
+// ─── Constants ────────────────────────────────────────────────────────────
+
+const CACHE_HEADER = 'x-astro-cache';
+
+/**
+ * Override for Astro's image endpoint: it hardcodes `max-age=31536000` without
+ * `s-maxage`, so without this override images would always bypass the cache.
+ */
+const IMAGE_CACHE_CONTROL =
+  'public, max-age=31536000, s-maxage=31536000, stale-while-revalidate=86400';
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+type CacheStatus = 'HIT' | 'STALE' | 'MISS' | 'BYPASS';
+
+type CacheDecision =
+  | { status: 'hit'; entry: CacheEntry }
+  | { status: 'stale'; entry: CacheEntry }
+  | { status: 'expired' }
+  | { status: 'miss' };
+
+export type ServerOptions = {
+  origin: (request: Request) => Promise<Response>;
+  maxByteSize: number;
+  cacheDir: string;
+  buildId: string;
+  warmOnInit: boolean;
+  imageEndpointRoute: string;
+};
+
+// ─── Pure: cache-control parsing ──────────────────────────────────────────
+
+/** Extract a numeric directive value from a Cache-Control header string. */
+function parseDirective(header: string, name: string): number | undefined {
+  const regex = new RegExp(`(?:^|,)\\s*${name}\\s*=\\s*(\\d+)`, 'i');
+  const match = header.match(regex);
+  return match ? Number(match[1]) : undefined;
+}
+
+/** Extract a cacheable entry from response data, or undefined if not cacheable. */
+function extractCacheableEntry(
+  headers: [string, string][],
+  status: number,
+  body: Uint8Array,
+  now: number,
+): CacheEntry | undefined {
+  const ccHeader = headers.find(([n]) => n === 'cache-control')?.[1] ?? '';
+  const sMaxAge = parseDirective(ccHeader, 's-maxage');
+  if (!sMaxAge || sMaxAge <= 0) return undefined;
+
+  return {
+    body,
+    headers,
+    status,
+    cachedAt: now,
+    sMaxAge,
+    swr: parseDirective(ccHeader, 'stale-while-revalidate') ?? 0,
+  };
+}
+
+// ─── Pure: image endpoint override ────────────────────────────────────────
+
+function isImageEndpointKey(key: string, route: string): boolean {
+  return key === route || key.startsWith(`${route}?`);
+}
+
+function overrideImageCacheControl(headers: [string, string][]): void {
+  for (let i = 0; i < headers.length; i++) {
+    if (headers[i]?.[0] === 'cache-control') {
+      headers[i] = ['cache-control', IMAGE_CACHE_CONTROL];
+      return;
+    }
+  }
+}
+
+// ─── Pure: cache decision ─────────────────────────────────────────────────
+
+/** Classify a cache lookup result against the current time. */
+function classifyEntry(
+  entry: CacheEntry | undefined,
+  now: number,
+): CacheDecision {
+  if (!entry) return { status: 'miss' };
+  const elapsed = now - entry.cachedAt;
+  if (elapsed < entry.sMaxAge * 1000) return { status: 'hit', entry };
+  if (elapsed < (entry.sMaxAge + entry.swr) * 1000) {
+    return { status: 'stale', entry };
+  }
+  return { status: 'expired' };
+}
+
+// ─── Pure: response construction ──────────────────────────────────────────
+
+function responseFromEntry(entry: CacheEntry, status: CacheStatus): Response {
+  const response = new Response(entry.body, {
+    status: entry.status,
+    headers: entry.headers,
+  });
+  response.headers.set(CACHE_HEADER, status);
+  return response;
+}
+
+// ─── Render path ──────────────────────────────────────────────────────────
+
+type RenderResult = {
+  streaming: Promise<Response>;
+  entry: Promise<CacheEntry | undefined>;
+};
+
+/**
+ * Render via origin, persist to cache if eligible, return streaming response
+ * + a promise resolving to the cached entry (or undefined if not cacheable).
+ *
+ * Both `streaming` and `entry` may reject if origin throws. Callers MUST
+ * either await/catch both, or use only one — the other will be silently
+ * swallowed by an internal handler to prevent unhandled rejection warnings.
+ */
+function renderAndCache(
+  request: Request,
+  origin: (request: Request) => Promise<Response>,
+  store: ReturnType<typeof createCacheStore>,
+  cacheKey: string,
+  initialStatus: CacheStatus,
+  imageEndpointRoute: string,
+  now: () => number,
+): RenderResult {
+  const done = origin(request).then((response) => {
+    const clone = response.clone();
+    const headers: [string, string][] = Array.from(clone.headers.entries());
+
+    if (isImageEndpointKey(cacheKey, imageEndpointRoute)) {
+      overrideImageCacheControl(headers);
+    }
+
+    const entryPromise = clone.arrayBuffer().then(async (buf) => {
+      const body = new Uint8Array(buf);
+      const entry = extractCacheableEntry(headers, clone.status, body, now());
+      if (entry) await store.set(cacheKey, entry);
+      return entry;
+    });
+
+    response.headers.set(CACHE_HEADER, initialStatus);
+    return { response, entryPromise };
+  });
+
+  // Pre-attach a no-op rejection handler so unawaited branches don't surface
+  // as unhandled rejections (the SWR path only consumes `entry`; the miss
+  // path may only consume `streaming`). Each consumer can still observe the
+  // rejection via its own .catch / await.
+  const streaming = done.then(({ response }) => response);
+  const entry = done.then(({ entryPromise }) => entryPromise);
+  streaming.catch(() => {});
+  entry.catch(() => {});
+
+  return { streaming, entry };
+}
+
+// ─── Public factory ───────────────────────────────────────────────────────
+
+/**
+ * Create a caching server with LRU storage, stale-while-revalidate, and
+ * request coalescing in front of an origin handler.
+ */
+export function createCacheServer(
+  options: ServerOptions,
+  deps: StoreDeps = defaultDeps(),
+): CacheServer {
+  const {
+    origin,
+    maxByteSize,
+    cacheDir,
+    buildId,
+    warmOnInit,
+    imageEndpointRoute,
+  } = options;
+
+  const store = createCacheStore(
+    { maxByteSize, cacheDir, buildId, warmOnInit },
+    deps,
+  );
+  const revalidationsInFlight = new Set<string>();
+  const rendersInFlight = new Map<string, Promise<CacheEntry | undefined>>();
+
+  const now = () => deps.clock.now();
+
+  const handler = (async (request: Request, cacheKey: string) => {
+    const decision = classifyEntry(await store.get(cacheKey), now());
+
+    if (decision.status === 'hit') {
+      return responseFromEntry(decision.entry, 'HIT');
+    }
+
+    if (decision.status === 'stale') {
+      if (!revalidationsInFlight.has(cacheKey)) {
+        revalidationsInFlight.add(cacheKey);
+        const result = renderAndCache(
+          new Request(request.url, request),
+          origin,
+          store,
+          cacheKey,
+          'STALE',
+          imageEndpointRoute,
+          now,
+        );
+        result.entry
+          .catch(() => {})
+          .finally(() => revalidationsInFlight.delete(cacheKey));
+      }
+      return responseFromEntry(decision.entry, 'STALE');
+    }
+
+    if (decision.status === 'expired') {
+      await store.delete(cacheKey);
+    }
+
+    // Miss or expired — coalesce concurrent renders for the same key.
+    const pending = rendersInFlight.get(cacheKey);
+    if (!pending) {
+      const result = renderAndCache(
+        request,
+        origin,
+        store,
+        cacheKey,
+        'MISS',
+        imageEndpointRoute,
+        now,
+      );
+      rendersInFlight.set(cacheKey, result.entry);
+      result.entry.finally(() => rendersInFlight.delete(cacheKey));
+      return result.streaming;
+    }
+
+    const cached = await pending;
+    if (cached) return responseFromEntry(cached, 'MISS');
+
+    // Not cacheable — direct origin call.
+    const response = await origin(request);
+    response.headers.set(CACHE_HEADER, 'BYPASS');
+    return response;
+  }) as CacheServer;
+
+  handler.shutdown = () => store.save();
+  handler.cache = {
+    expire: (key) => store.delete(key),
+    expireAll: async () => {
+      const deletes: Promise<void>[] = [];
+      for (const key of [...store.keys]) {
+        if (isImageEndpointKey(key, imageEndpointRoute)) continue;
+        deletes.push(store.delete(key));
+      }
+      await Promise.all(deletes);
+    },
+  } satisfies CacheControl;
+
+  return handler;
+}
+
+// ─── Test-only exports ────────────────────────────────────────────────────
+
+/** @internal Exposed only for unit tests. Do not use. */
+export const __test__ = {
+  parseDirective,
+  extractCacheableEntry,
+  isImageEndpointKey,
+  overrideImageCacheControl,
+  classifyEntry,
+  responseFromEntry,
+};

--- a/packages/astro-bun/src/cache/store.test.ts
+++ b/packages/astro-bun/src/cache/store.test.ts
@@ -1,0 +1,1164 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CacheEntry } from '../types.ts';
+import {
+  __test__,
+  type Clock,
+  createCacheStore,
+  defaultDeps,
+  type FileSystem,
+  type StoreDeps,
+} from './store.ts';
+
+// ═════════════════════════════════════════════════════════════════════════
+// Test helpers
+// ═════════════════════════════════════════════════════════════════════════
+
+type FakeFileSystem = FileSystem & {
+  files: Map<string, string>;
+  failOnce: (op: 'read' | 'write' | 'remove' | 'mkdir', match?: string) => void;
+};
+
+function createFakeFileSystem(): FakeFileSystem {
+  const files = new Map<string, string>();
+  const failures: { op: string; match?: string }[] = [];
+
+  const checkFail = (op: string, path: string) => {
+    const idx = failures.findIndex(
+      (f) => f.op === op && (f.match === undefined || path.includes(f.match)),
+    );
+    if (idx >= 0) {
+      failures.splice(idx, 1);
+      throw new Error(`fake ${op} failure on ${path}`);
+    }
+  };
+
+  return {
+    files,
+    failOnce(op, match) {
+      failures.push({ op, match });
+    },
+    async read(path) {
+      checkFail('read', path);
+      return files.get(path);
+    },
+    async write(path, data) {
+      checkFail('write', path);
+      files.set(path, data);
+    },
+    async remove(path) {
+      checkFail('remove', path);
+      files.delete(path);
+    },
+    async exists(path) {
+      return files.has(path);
+    },
+    async mkdir(path) {
+      checkFail('mkdir', path);
+    },
+    async removeDir(path) {
+      const prefix = path.endsWith('/') ? path : `${path}/`;
+      for (const f of [...files.keys()]) {
+        if (f === path || f.startsWith(prefix)) files.delete(f);
+      }
+    },
+  };
+}
+
+type FakeClock = Clock & {
+  advance: (ms: number) => void;
+  pendingTimers: () => number;
+};
+
+type FakeTimer = { dueAt: number; fn: () => void; cleared: boolean };
+
+function createFakeClock(initialNow = 1_000_000): FakeClock {
+  let now = initialNow;
+  const timers: FakeTimer[] = [];
+
+  return {
+    now: () => now,
+    setTimeout(fn, ms) {
+      const timer: FakeTimer = { dueAt: now + ms, fn, cleared: false };
+      timers.push(timer);
+      return {
+        clear() {
+          timer.cleared = true;
+        },
+      };
+    },
+    advance(ms) {
+      const target = now + ms;
+      while (true) {
+        const due = timers
+          .filter((t) => !t.cleared && t.dueAt <= target)
+          .sort((a, b) => a.dueAt - b.dueAt)[0];
+        if (!due) break;
+        now = due.dueAt;
+        due.cleared = true;
+        due.fn();
+      }
+      now = target;
+    },
+    pendingTimers() {
+      return timers.filter((t) => !t.cleared).length;
+    },
+  };
+}
+
+type FakeDeps = StoreDeps & { fs: FakeFileSystem; clock: FakeClock };
+
+function fakeDeps(initialNow?: number): FakeDeps {
+  return {
+    fs: createFakeFileSystem(),
+    clock: createFakeClock(initialNow),
+    hash: (k) => `h_${k}`,
+  };
+}
+
+const BUILD_ID = 'b1';
+const CACHE_DIR = '/cache';
+
+function entry(size: number, overrides: Partial<CacheEntry> = {}): CacheEntry {
+  return {
+    body: new Uint8Array(size),
+    headers: [],
+    status: 200,
+    cachedAt: 0,
+    sMaxAge: 60,
+    swr: 0,
+    ...overrides,
+  };
+}
+
+function tmpDir() {
+  return join(
+    tmpdir(),
+    `store-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+}
+
+describe('Cache', () => {
+  describe('List Operations', () => {
+    test('createListSentinel — self-referential', () => {
+      const s = __test__.createListSentinel();
+      expect(s.older).toBe(s);
+      expect(s.newer).toBe(s);
+    });
+
+    test('listInsertFront / listDetach / listMoveToFront', () => {
+      const head = __test__.createListSentinel();
+      const tail = __test__.createListSentinel();
+      head.newer = tail;
+      tail.older = head;
+
+      const a = __test__.createListEntry('a', entry(1), 1);
+      const b = __test__.createListEntry('b', entry(1), 1);
+      const c = __test__.createListEntry('c', entry(1), 1);
+
+      // Use a helper that erases the union narrowing — we just want pointer equality.
+      const same = (x: unknown, y: unknown) => Object.is(x, y);
+
+      __test__.listInsertFront(head, a);
+      __test__.listInsertFront(head, b);
+      __test__.listInsertFront(head, c);
+      // Order from head: c, b, a, tail
+      expect(same(head.newer, c)).toBe(true);
+      expect(same(c.newer, b)).toBe(true);
+      expect(same(b.newer, a)).toBe(true);
+      expect(same(a.newer, tail)).toBe(true);
+
+      __test__.listMoveToFront(head, a);
+      expect(same(head.newer, a)).toBe(true);
+      expect(same(a.newer, c)).toBe(true);
+
+      __test__.listDetach(b);
+      expect(same(c.newer, tail)).toBe(true);
+      expect(same(tail.older, c)).toBe(true);
+    });
+  });
+
+  describe('Serialization', () => {
+    test('encodeEntry / decodeEntry roundtrip', () => {
+      const original: CacheEntry = {
+        body: new Uint8Array([1, 2, 3, 255]),
+        headers: [['x-test', 'value']],
+        status: 200,
+        cachedAt: 12345,
+        sMaxAge: 60,
+        swr: 30,
+      };
+      const decoded = __test__.decodeEntry(__test__.encodeEntry(original));
+      expect(decoded.body).toEqual(original.body);
+      expect(decoded.headers).toEqual(original.headers);
+      expect(decoded.status).toBe(original.status);
+      expect(decoded.cachedAt).toBe(original.cachedAt);
+      expect(decoded.sMaxAge).toBe(original.sMaxAge);
+      expect(decoded.swr).toBe(original.swr);
+    });
+  });
+
+  describe('Store > Basic Operations', () => {
+    test('get/set/get round-trip', async () => {
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        fakeDeps(),
+      );
+      await store.set('a', entry(100));
+      const result = await store.get('a');
+      expect(result?.body.byteLength).toBe(100);
+      await store.destroy();
+    });
+
+    test('get on missing key returns undefined', async () => {
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        fakeDeps(),
+      );
+      expect(await store.get('missing')).toBeUndefined();
+      await store.destroy();
+    });
+
+    test('delete removes from memory and disk', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(100));
+      expect(
+        deps.fs.files.has(`${CACHE_DIR}/${BUILD_ID}/entries/h_a.json`),
+      ).toBe(true);
+      await store.delete('a');
+      expect(
+        deps.fs.files.has(`${CACHE_DIR}/${BUILD_ID}/entries/h_a.json`),
+      ).toBe(false);
+      expect(await store.get('a')).toBeUndefined();
+      await store.destroy();
+    });
+
+    test('delete on missing key is a no-op', async () => {
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        fakeDeps(),
+      );
+      await store.delete('never-set');
+      await store.destroy();
+    });
+
+    test('keys getter exposes persisted keys', async () => {
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        fakeDeps(),
+      );
+      await store.set('a', entry(50));
+      await store.set('b', entry(50));
+      expect(store.keys.has('a')).toBe(true);
+      expect(store.keys.has('b')).toBe(true);
+      expect(store.keys.size).toBe(2);
+      await store.destroy();
+    });
+
+    test('set with size > maxByteSize is rejected silently', async () => {
+      const store = createCacheStore(
+        {
+          maxByteSize: 100,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        fakeDeps(),
+      );
+      await store.set('huge', entry(200));
+      expect(await store.get('huge')).toBeUndefined();
+      expect(store.keys.has('huge')).toBe(false);
+      await store.destroy();
+    });
+
+    test('set updates existing entry size correctly', async () => {
+      const store = createCacheStore(
+        {
+          maxByteSize: 200,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        fakeDeps(),
+      );
+      await store.set('a', entry(100));
+      await store.set('a', entry(150)); // overwrite
+      await store.set('b', entry(50));
+      // Total = 150 + 50 = 200, both fit
+      expect(await store.get('a')).toBeDefined();
+      expect(await store.get('b')).toBeDefined();
+      await store.destroy();
+    });
+  });
+
+  describe('Store > LRU Eviction', () => {
+    test('evicts oldest when over budget, keeps on disk', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 200,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(100));
+      await store.set('b', entry(100));
+      await store.set('c', entry(100)); // evicts 'a' from memory
+
+      // 'a' still on disk
+      expect(
+        deps.fs.files.has(`${CACHE_DIR}/${BUILD_ID}/entries/h_a.json`),
+      ).toBe(true);
+      // 'a' still retrievable via disk fallback
+      const a = await store.get('a');
+      expect(a).toBeDefined();
+      await store.destroy();
+    });
+
+    test('get promotes to MRU position', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 200,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(100));
+      await store.set('b', entry(100));
+      await store.get('a'); // promote a → MRU
+      await store.set('c', entry(100)); // evicts b (now LRU)
+
+      // 'a' should still be there in memory after eviction
+      // (verifiable via load-tracking the fake fs reads)
+      const reads: string[] = [];
+      const origRead = deps.fs.read.bind(deps.fs);
+      deps.fs.read = async (p: string) => {
+        reads.push(p);
+        return origRead(p);
+      };
+
+      await store.get('a');
+      // No disk read for 'a' — still in memory
+      expect(reads.some((r) => r.includes('h_a.json'))).toBe(false);
+      await store.destroy();
+    });
+  });
+
+  describe('Store > Persistence', () => {
+    test('save flushes pending writes and writes index', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      await store.set('b', entry(50));
+      await store.save();
+
+      const indexRaw = deps.fs.files.get(`${CACHE_DIR}/${BUILD_ID}/index.json`);
+      expect(indexRaw).toBeDefined();
+      const index = JSON.parse(indexRaw as string);
+      expect(Object.keys(index)).toHaveLength(2);
+      expect(index.h_a).toBe('a');
+      expect(index.h_b).toBe('b');
+      await store.destroy();
+    });
+
+    test('reload from existing index — keys appear in store.keys', async () => {
+      const deps = fakeDeps();
+      // First lifecycle
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('a', entry(50));
+      await store1.set('b', entry(50));
+      await store1.save();
+      await store1.destroy();
+
+      // Second lifecycle, same fs
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      // Force ready
+      await store2.get('__force_ready__');
+      expect(store2.keys.has('a')).toBe(true);
+      expect(store2.keys.has('b')).toBe(true);
+
+      const a = await store2.get('a');
+      expect(a?.body.byteLength).toBe(50);
+      await store2.destroy();
+    });
+
+    test('reload with missing index — starts fresh', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      expect(await store.get('a')).toBeUndefined();
+      expect(store.keys.size).toBe(0);
+      await store.destroy();
+    });
+
+    test('reload with corrupted index — starts fresh', async () => {
+      const deps = fakeDeps();
+      deps.fs.files.set(
+        `${CACHE_DIR}/${BUILD_ID}/index.json`,
+        'not valid json',
+      );
+
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      expect(await store.get('a')).toBeUndefined();
+      expect(store.keys.size).toBe(0);
+      await store.destroy();
+    });
+
+    test('reload with corrupted entry file — get returns undefined and untracks', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('a', entry(50));
+      await store1.save();
+      await store1.destroy();
+
+      // Corrupt the entry file
+      deps.fs.files.set(`${CACHE_DIR}/${BUILD_ID}/entries/h_a.json`, 'garbage');
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      expect(await store2.get('a')).toBeUndefined();
+      await store2.destroy();
+    });
+
+    test('reload with missing entry file — get returns undefined', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('a', entry(50));
+      await store1.save();
+      await store1.destroy();
+
+      // Delete entry file but keep index pointing to it
+      deps.fs.files.delete(`${CACHE_DIR}/${BUILD_ID}/entries/h_a.json`);
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      expect(await store2.get('a')).toBeUndefined();
+      await store2.destroy();
+    });
+
+    test('warmOnInit=true — preloads into memory', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      for (let i = 0; i < 10; i++) await store1.set(`k${i}`, entry(10));
+      await store1.save();
+      await store1.destroy();
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: true,
+        },
+        deps,
+      );
+      // Trigger ready resolution
+      await store2.get('__warmup__');
+      // Yield to let warmCacheFromDisk finish
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+
+      // Now reads should hit memory — verify by tracking subsequent reads
+      const reads: string[] = [];
+      const origRead = deps.fs.read.bind(deps.fs);
+      deps.fs.read = async (p: string) => {
+        reads.push(p);
+        return origRead(p);
+      };
+      await store2.get('k0');
+      expect(reads.length).toBe(0);
+      await store2.destroy();
+    });
+
+    test('warmOnInit respects budget — stops when over budget', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 10_000,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      for (let i = 0; i < 20; i++) await store1.set(`k${i}`, entry(100));
+      await store1.save();
+      await store1.destroy();
+
+      // Smaller budget on reload — warm should bail early
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 300,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: true,
+        },
+        deps,
+      );
+      await store2.get('__force_ready__');
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+      // All 20 keys still tracked (persisted), but memory budget caps loaded count
+      expect(store2.keys.size).toBe(20);
+      await store2.destroy();
+    });
+  });
+
+  describe('Store > Vacuum Old Builds', () => {
+    test('removes old build dirs, preserves current', async () => {
+      const deps = fakeDeps();
+
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: 'old-build',
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('a', entry(50));
+      await store1.save();
+      await store1.destroy();
+
+      expect(deps.fs.files.has(`${CACHE_DIR}/old-build/index.json`)).toBe(true);
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: 'new-build',
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store2.get('__force_ready__');
+      expect(deps.fs.files.has(`${CACHE_DIR}/old-build/index.json`)).toBe(
+        false,
+      );
+      await store2.destroy();
+    });
+
+    test('preserves current build on subsequent open', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('a', entry(50));
+      await store1.save();
+      await store1.destroy();
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      const a = await store2.get('a');
+      expect(a?.body.byteLength).toBe(50);
+      await store2.destroy();
+    });
+
+    test('corrupted manifest — fresh start', async () => {
+      const deps = fakeDeps();
+      deps.fs.files.set(`${CACHE_DIR}/manifest.json`, 'broken');
+
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      expect(await store.get('a')).toBeDefined();
+      await store.destroy();
+    });
+
+    test('manifest with no buildIds — works fine', async () => {
+      const deps = fakeDeps();
+      deps.fs.files.set(
+        `${CACHE_DIR}/manifest.json`,
+        JSON.stringify({ buildIds: [] }),
+      );
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      expect(await store.get('a')).toBeDefined();
+      await store.destroy();
+    });
+  });
+
+  describe('Store > Index Debouncing', () => {
+    test('debounced index write — fires after 1s via clock advance', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      // The disk write is fire-and-forget; flush microtasks so its `.then`
+      // chain (which schedules the index timer) actually runs.
+      await new Promise((r) => setImmediate(r));
+      expect(deps.clock.pendingTimers()).toBeGreaterThan(0);
+
+      deps.clock.advance(1000);
+      // Yield so the index write promise (kicked off by the timer) resolves.
+      await new Promise((r) => setImmediate(r));
+
+      expect(deps.fs.files.has(`${CACHE_DIR}/${BUILD_ID}/index.json`)).toBe(
+        true,
+      );
+      await store.destroy();
+    });
+
+    test('save clears pending timer and writes index immediately', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      await store.save();
+      expect(deps.clock.pendingTimers()).toBe(0);
+      expect(deps.fs.files.has(`${CACHE_DIR}/${BUILD_ID}/index.json`)).toBe(
+        true,
+      );
+      await store.destroy();
+    });
+
+    test('multiple sets coalesce into single index write', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      await store.set('b', entry(50));
+      await store.set('c', entry(50));
+      // Flush microtasks so all three pending writes have scheduled their timers.
+      await new Promise((r) => setImmediate(r));
+      // Only one pending timer, not three
+      expect(deps.clock.pendingTimers()).toBe(1);
+      await store.destroy();
+    });
+  });
+
+  describe('Store > Error Paths', () => {
+    test('write failure during set is swallowed', async () => {
+      const deps = fakeDeps();
+      deps.fs.failOnce('write', 'h_a.json');
+
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      // Should not throw
+      await store.set('a', entry(50));
+      // Memory copy still there
+      expect(await store.get('a')).toBeDefined();
+      await store.destroy();
+    });
+
+    test('remove failure during delete is swallowed', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      deps.fs.failOnce('remove', 'h_a.json');
+      await store.delete('a'); // should not throw
+      await store.destroy();
+    });
+
+    test('destroy swallows index write failure', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      // Wait for the entry write to settle so the failOnce only catches the index write.
+      await new Promise((r) => setImmediate(r));
+      deps.fs.failOnce('write', 'index.json');
+      await store.destroy(); // should not throw
+    });
+
+    test('scheduled index write failure is swallowed', async () => {
+      const deps = fakeDeps();
+      const store = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store.set('a', entry(50));
+      // Flush so the timer is scheduled.
+      await new Promise((r) => setImmediate(r));
+      // Make the upcoming index write fail.
+      deps.fs.failOnce('write', 'index.json');
+      // Trigger the debounced timer — the catch in scheduleIndexWrite should swallow.
+      deps.clock.advance(1000);
+      // Yield so the rejection surfaces and gets caught.
+      await new Promise((r) => setImmediate(r));
+      // Index file was never written
+      expect(deps.fs.files.has(`${CACHE_DIR}/${BUILD_ID}/index.json`)).toBe(
+        false,
+      );
+      await store.destroy();
+    });
+  });
+
+  describe('Store > Concurrency', () => {
+    test('concurrent gets for same disk-only key share one read', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 200,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('a', entry(50));
+      await store1.save();
+      await store1.destroy();
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 200,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+
+      const reads: string[] = [];
+      const origRead = deps.fs.read.bind(deps.fs);
+      deps.fs.read = async (p: string) => {
+        reads.push(p);
+        return origRead(p);
+      };
+
+      // Force ready first so read counts after start cleanly
+      await store2.get('__warmup__');
+      reads.length = 0;
+
+      const results = await Promise.all([
+        store2.get('a'),
+        store2.get('a'),
+        store2.get('a'),
+      ]);
+      for (const r of results) expect(r).toBeDefined();
+
+      const entryReads = reads.filter((r) => r.includes('h_a.json'));
+      expect(entryReads.length).toBe(1);
+
+      await store2.destroy();
+    });
+
+    test('get during in-flight load — joins existing promise', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 200,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('a', entry(50));
+      await store1.save();
+      await store1.destroy();
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 200,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store2.get('__warmup__');
+
+      const p1 = store2.get('a');
+      const p2 = store2.get('a');
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1).toBeDefined();
+      expect(r2).toBeDefined();
+      await store2.destroy();
+    });
+
+    test('set during in-flight load promotes existing memory entry', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store1.set('contested', entry(100));
+      await store1.save();
+      await store1.destroy();
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 1024,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      await store2.get('__warmup__');
+
+      // Trigger disk load
+      const getP = store2.get('contested');
+      // Race: set arrives, populating memory before disk load resolves
+      await store2.set('contested', entry(50));
+
+      const result = await getP;
+      expect(result).toBeDefined();
+      await store2.destroy();
+    });
+
+    test('warmOnInit shares pendingLoad with concurrent get', async () => {
+      const deps = fakeDeps();
+      const store1 = createCacheStore(
+        {
+          maxByteSize: 4096,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: false,
+        },
+        deps,
+      );
+      // More than one batch (BATCH_SIZE = 8)
+      for (let i = 0; i < 16; i++) await store1.set(`k${i}`, entry(10));
+      await store1.save();
+      await store1.destroy();
+
+      const store2 = createCacheStore(
+        {
+          maxByteSize: 4096,
+          cacheDir: CACHE_DIR,
+          buildId: BUILD_ID,
+          warmOnInit: true,
+        },
+        deps,
+      );
+
+      // While warm is running, fire concurrent gets
+      const gets: Promise<unknown>[] = [];
+      for (let i = 0; i < 16; i++) gets.push(store2.get(`k${i}`));
+
+      const results = await Promise.all(gets);
+      for (const r of results) expect(r).toBeDefined();
+
+      // Let warm complete
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+      await store2.destroy();
+    });
+  });
+
+  describe('Default Dependencies', () => {
+    test('end-to-end with real filesystem', async () => {
+      const dir = tmpDir();
+      const store = createCacheStore({
+        maxByteSize: 1024,
+        cacheDir: dir,
+        buildId: BUILD_ID,
+        warmOnInit: false,
+      });
+
+      await store.set('a', {
+        body: new Uint8Array([1, 2, 3]),
+        headers: [['x-test', 'val']],
+        status: 200,
+        cachedAt: Date.now(),
+        sMaxAge: 60,
+        swr: 0,
+      });
+      await store.save();
+
+      // Files exist on disk
+      const indexPath = join(dir, BUILD_ID, 'index.json');
+      expect(existsSync(indexPath)).toBe(true);
+      const index = JSON.parse(await Bun.file(indexPath).text());
+      const hash = Object.keys(index)[0];
+      expect(existsSync(join(dir, BUILD_ID, 'entries', `${hash}.json`))).toBe(
+        true,
+      );
+
+      await store.destroy();
+
+      // Reload from disk
+      const store2 = createCacheStore({
+        maxByteSize: 1024,
+        cacheDir: dir,
+        buildId: BUILD_ID,
+        warmOnInit: true,
+      });
+      const a = await store2.get('a');
+      expect(a).toBeDefined();
+      expect(Array.from(a?.body ?? [])).toEqual([1, 2, 3]);
+      await store2.destroy();
+    });
+
+    test('clock returns Date.now()', () => {
+      const deps = defaultDeps();
+      const before = Date.now();
+      const now = deps.clock.now();
+      const after = Date.now();
+      expect(now).toBeGreaterThanOrEqual(before);
+      expect(now).toBeLessThanOrEqual(after);
+    });
+
+    test('hash is deterministic sha256', () => {
+      const deps = defaultDeps();
+      const a = deps.hash('hello');
+      const b = deps.hash('hello');
+      const c = deps.hash('world');
+      expect(a).toBe(b);
+      expect(a).not.toBe(c);
+      expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    test('fs.read returns undefined for missing file', async () => {
+      const deps = defaultDeps();
+      expect(
+        await deps.fs.read(`/tmp/nonexistent-${Math.random()}`),
+      ).toBeUndefined();
+    });
+
+    test('fs round-trip', async () => {
+      const deps = defaultDeps();
+      const dir = tmpDir();
+      mkdirSync(dir, { recursive: true });
+      const path = join(dir, 'test.txt');
+      expect(await deps.fs.exists(path)).toBe(false);
+      await deps.fs.write(path, 'hello');
+      expect(await deps.fs.exists(path)).toBe(true);
+      expect(await deps.fs.read(path)).toBe('hello');
+      await deps.fs.remove(path);
+      expect(await deps.fs.exists(path)).toBe(false);
+    });
+
+    test('fs.mkdir creates nested directories', async () => {
+      const deps = defaultDeps();
+      const dir = tmpDir();
+      const nested = join(dir, 'a', 'b', 'c');
+      await deps.fs.mkdir(nested);
+      // Verify by writing a file inside it
+      const path = join(nested, 'file.txt');
+      await deps.fs.write(path, 'ok');
+      expect(await deps.fs.read(path)).toBe('ok');
+    });
+
+    test('fs.removeDir removes recursively', async () => {
+      const deps = defaultDeps();
+      const dir = tmpDir();
+      const sub = join(dir, 'sub');
+      await deps.fs.mkdir(sub);
+      await deps.fs.write(join(sub, 'a.txt'), 'a');
+      await deps.fs.write(join(sub, 'b.txt'), 'b');
+      expect(await deps.fs.exists(join(sub, 'a.txt'))).toBe(true);
+      await deps.fs.removeDir(sub);
+      expect(await deps.fs.exists(join(sub, 'a.txt'))).toBe(false);
+      expect(await deps.fs.exists(sub)).toBe(false);
+    });
+
+    test('clock.setTimeout fires and is clearable', async () => {
+      const deps = defaultDeps();
+      let fired = false;
+      const handle = deps.clock.setTimeout(() => {
+        fired = true;
+      }, 5);
+      await new Promise((r) => setTimeout(r, 20));
+      expect(fired).toBe(true);
+
+      let firedClearable = false;
+      const handle2 = deps.clock.setTimeout(() => {
+        firedClearable = true;
+      }, 5);
+      handle2.clear();
+      await new Promise((r) => setTimeout(r, 20));
+      expect(firedClearable).toBe(false);
+      // Just to keep handle in scope and exercise the type
+      expect(handle).toBeDefined();
+    });
+  });
+});

--- a/packages/astro-bun/src/cache/store.ts
+++ b/packages/astro-bun/src/cache/store.ts
@@ -1,0 +1,530 @@
+import { mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { CacheEntry } from '../types.ts';
+
+/**
+ * Two-tier byte-limited LRU cache (functional).
+ *
+ * L1: in-memory LRU via doubly-linked list nodes.
+ * L2: per-entry JSON files on disk.
+ *
+ * Evicted entries stay on disk and reload on next get().
+ * TTL is not enforced here — `serve.ts` checks cachedAt + sMaxAge.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+type ListSentinel = {
+  kind: 'sentinel';
+  older: ListNode;
+  newer: ListNode;
+};
+
+type ListEntry = {
+  kind: 'entry';
+  key: string;
+  value: CacheEntry;
+  size: number;
+  older: ListNode;
+  newer: ListNode;
+};
+
+type ListNode = ListSentinel | ListEntry;
+
+type StoreState = {
+  entries: Map<string, ListEntry>;
+  head: ListSentinel;
+  tail: ListSentinel;
+  currentBytes: number;
+  maxByteSize: number;
+  cacheDir: string;
+  buildId: string;
+  warmOnInit: boolean;
+  entriesDir: string;
+  indexPath: string;
+  persistedKeys: Set<string>;
+  keyHashes: Map<string, string>;
+  entriesDirCreated: boolean;
+  indexDirty: boolean;
+  indexTimer: ReturnType<typeof setTimeout> | undefined;
+  pendingWrites: Set<Promise<void>>;
+  pendingLoads: Map<string, Promise<CacheEntry | undefined>>;
+  ready: Promise<void> | true;
+  deps: StoreDeps;
+};
+
+export type StoreOptions = {
+  maxByteSize: number;
+  cacheDir: string;
+  buildId: string;
+  warmOnInit: boolean;
+};
+
+export type StoreDeps = {
+  fs: FileSystem;
+  clock: Clock;
+  hash: (input: string) => string;
+};
+
+export type FileSystem = {
+  read: (path: string) => Promise<string | undefined>;
+  write: (path: string, data: string) => Promise<void>;
+  remove: (path: string) => Promise<void>;
+  exists: (path: string) => Promise<boolean>;
+  mkdir: (path: string) => Promise<void>;
+  removeDir: (path: string) => Promise<void>;
+};
+
+export type Clock = {
+  now: () => number;
+  setTimeout: (fn: () => void, ms: number) => TimerHandle;
+};
+
+export type TimerHandle = {
+  clear: () => void;
+};
+
+export type CacheStore = {
+  get: (key: string) => Promise<CacheEntry | undefined>;
+  set: (key: string, value: CacheEntry) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+  keys: ReadonlySet<string>;
+  save: () => Promise<void>;
+  destroy: () => Promise<void>;
+};
+
+// ─── Pure: LRU list operations ────────────────────────────────────────────
+
+function createListSentinel(): ListSentinel {
+  const node = { kind: 'sentinel' } as ListSentinel;
+  node.older = node;
+  node.newer = node;
+  return node;
+}
+
+function createListEntry(
+  key: string,
+  value: CacheEntry,
+  size: number,
+): ListEntry {
+  return { kind: 'entry', key, value, size } as ListEntry;
+}
+
+function listInsertFront(head: ListSentinel, node: ListEntry): void {
+  node.older = head;
+  node.newer = head.newer;
+  head.newer.older = node;
+  head.newer = node;
+}
+
+function listDetach(node: ListEntry): void {
+  node.older.newer = node.newer;
+  node.newer.older = node.older;
+}
+
+function listMoveToFront(head: ListSentinel, node: ListEntry): void {
+  listDetach(node);
+  listInsertFront(head, node);
+}
+
+// ─── Pure: serialization ──────────────────────────────────────────────────
+
+function encodeEntry(entry: CacheEntry): string {
+  return JSON.stringify({ ...entry, body: Array.from(entry.body) });
+}
+
+function decodeEntry(raw: string): CacheEntry {
+  const parsed = JSON.parse(raw);
+  return { ...parsed, body: new Uint8Array(parsed.body) };
+}
+
+// ─── Pure: eviction ───────────────────────────────────────────────────────
+
+function evictUntilUnderBudget(state: StoreState): void {
+  while (state.currentBytes > state.maxByteSize && state.entries.size > 0) {
+    const oldest = state.tail.older;
+    if (oldest.kind === 'sentinel') break;
+    listDetach(oldest);
+    state.entries.delete(oldest.key);
+    state.currentBytes -= oldest.size;
+  }
+}
+
+// ─── Default IO adapters (Bun-backed) ─────────────────────────────────────
+
+function defaultFileSystem(): FileSystem {
+  return {
+    async read(path) {
+      const file = Bun.file(path);
+      if (!(await file.exists())) return undefined;
+      return file.text();
+    },
+    async write(path, data) {
+      await Bun.write(path, data);
+    },
+    async remove(path) {
+      await rm(path, { force: true });
+    },
+    async exists(path) {
+      return Bun.file(path).exists();
+    },
+    async mkdir(path) {
+      await mkdir(path, { recursive: true });
+    },
+    async removeDir(path) {
+      await rm(path, { recursive: true, force: true });
+    },
+  };
+}
+
+function defaultClock(): Clock {
+  return {
+    now: () => Date.now(),
+    setTimeout(fn, ms) {
+      const t = setTimeout(fn, ms);
+      t.unref();
+      return { clear: () => clearTimeout(t) };
+    },
+  };
+}
+
+function defaultHash(input: string): string {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(input);
+  return hasher.digest('hex');
+}
+
+export function defaultDeps(): StoreDeps {
+  return {
+    fs: defaultFileSystem(),
+    clock: defaultClock(),
+    hash: defaultHash,
+  };
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────
+
+function hashKey(state: StoreState, key: string): string {
+  const cached = state.keyHashes.get(key);
+  if (cached) return cached;
+  const hex = state.deps.hash(key);
+  state.keyHashes.set(key, hex);
+  return hex;
+}
+
+function entryFilePath(state: StoreState, hash: string): string {
+  return join(state.entriesDir, `${hash}.json`);
+}
+
+async function ensureEntriesDir(state: StoreState): Promise<void> {
+  if (state.entriesDirCreated) return;
+  await state.deps.fs.mkdir(state.entriesDir);
+  state.entriesDirCreated = true;
+}
+
+async function writeEntryToDisk(
+  state: StoreState,
+  key: string,
+  value: CacheEntry,
+): Promise<void> {
+  const hash = hashKey(state, key);
+  await ensureEntriesDir(state);
+  await state.deps.fs.write(entryFilePath(state, hash), encodeEntry(value));
+  state.indexDirty = true;
+  scheduleIndexWrite(state);
+}
+
+async function readEntryFromDisk(
+  state: StoreState,
+  key: string,
+): Promise<CacheEntry | undefined> {
+  try {
+    const hash = hashKey(state, key);
+    const raw = await state.deps.fs.read(entryFilePath(state, hash));
+    if (raw === undefined) {
+      state.persistedKeys.delete(key);
+      state.keyHashes.delete(key);
+      return undefined;
+    }
+    const entry = decodeEntry(raw);
+
+    const existing = state.entries.get(key);
+    if (existing) {
+      listMoveToFront(state.head, existing);
+      return existing.value;
+    }
+
+    const size = entry.body.byteLength;
+    const node = createListEntry(key, entry, size);
+    state.entries.set(key, node);
+    listInsertFront(state.head, node);
+    state.currentBytes += size;
+    evictUntilUnderBudget(state);
+
+    return entry;
+  } catch {
+    state.persistedKeys.delete(key);
+    state.keyHashes.delete(key);
+    return undefined;
+  } finally {
+    state.pendingLoads.delete(key);
+  }
+}
+
+async function removeEntryFromDisk(
+  state: StoreState,
+  key: string,
+): Promise<void> {
+  const hash = hashKey(state, key);
+  state.persistedKeys.delete(key);
+  state.keyHashes.delete(key);
+  await state.deps.fs.remove(entryFilePath(state, hash));
+  state.indexDirty = true;
+  scheduleIndexWrite(state);
+}
+
+// ─── Index file ───────────────────────────────────────────────────────────
+
+async function writeIndex(state: StoreState): Promise<void> {
+  if (!state.indexDirty) return;
+  const index: Record<string, string> = {};
+  for (const [key, hash] of state.keyHashes) {
+    if (state.persistedKeys.has(key)) index[hash] = key;
+  }
+  await state.deps.fs.write(state.indexPath, JSON.stringify(index));
+  state.indexDirty = false;
+}
+
+function scheduleIndexWrite(state: StoreState): void {
+  if (state.indexTimer || !state.indexDirty) return;
+  state.indexTimer = state.deps.clock.setTimeout(() => {
+    state.indexTimer = undefined;
+    writeIndex(state).catch(() => {});
+  }, 1000) as unknown as ReturnType<typeof setTimeout>;
+}
+
+function clearIndexTimer(state: StoreState): void {
+  if (!state.indexTimer) return;
+  (state.indexTimer as unknown as TimerHandle).clear();
+  state.indexTimer = undefined;
+}
+
+// ─── Build directory lifecycle ────────────────────────────────────────────
+
+async function vacuumOldBuilds(state: StoreState): Promise<void> {
+  const manifestPath = join(state.cacheDir, 'manifest.json');
+  let manifest: { buildIds: string[] } = { buildIds: [] };
+  const raw = await state.deps.fs.read(manifestPath);
+  if (raw !== undefined) {
+    try {
+      manifest = JSON.parse(raw);
+    } catch {
+      /* start fresh */
+    }
+  }
+
+  for (const oldId of manifest.buildIds) {
+    if (oldId === state.buildId) continue;
+    await state.deps.fs.removeDir(join(state.cacheDir, oldId));
+  }
+
+  await state.deps.fs.mkdir(state.cacheDir);
+  await state.deps.fs.write(
+    manifestPath,
+    JSON.stringify({ buildIds: [state.buildId] }),
+  );
+}
+
+async function initFromDisk(state: StoreState): Promise<void> {
+  await vacuumOldBuilds(state);
+  await ensureEntriesDir(state);
+
+  const raw = await state.deps.fs.read(state.indexPath);
+  if (raw === undefined) {
+    state.ready = true;
+    return;
+  }
+
+  let index: Record<string, string>;
+  try {
+    index = JSON.parse(raw);
+  } catch {
+    state.ready = true;
+    return;
+  }
+
+  for (const [hash, key] of Object.entries(index)) {
+    state.persistedKeys.add(key);
+    state.keyHashes.set(key, hash);
+  }
+  state.ready = true;
+
+  if (state.warmOnInit) void warmCacheFromDisk(state, index);
+}
+
+async function warmCacheFromDisk(
+  state: StoreState,
+  index: Record<string, string>,
+): Promise<void> {
+  const BATCH_SIZE = 8;
+  const keys = Object.values(index);
+
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    if (state.currentBytes >= state.maxByteSize) break;
+
+    const batch: Promise<CacheEntry | undefined>[] = [];
+    for (let j = i; j < Math.min(i + BATCH_SIZE, keys.length); j++) {
+      const key = keys[j];
+      if (!key) continue;
+      if (state.entries.has(key)) continue;
+      if (state.currentBytes >= state.maxByteSize) break;
+
+      const inflight = state.pendingLoads.get(key);
+      if (inflight) {
+        batch.push(inflight);
+        continue;
+      }
+
+      const p = readEntryFromDisk(state, key);
+      state.pendingLoads.set(key, p);
+      batch.push(p);
+    }
+
+    await Promise.all(batch);
+  }
+}
+
+async function ensureReady(state: StoreState): Promise<void> {
+  if (state.ready !== true) await state.ready;
+}
+
+function trackWrite(state: StoreState, p: Promise<void>): void {
+  state.pendingWrites.add(p);
+  void p.finally(() => state.pendingWrites.delete(p));
+}
+
+// ─── Public factory ───────────────────────────────────────────────────────
+
+/** Create a persistent two-tier LRU cache (L1 memory + L2 disk). */
+export function createCacheStore(
+  options: StoreOptions,
+  deps: StoreDeps = defaultDeps(),
+): CacheStore {
+  const head = createListSentinel();
+  const tail = createListSentinel();
+  head.newer = tail;
+  tail.older = head;
+
+  const state: StoreState = {
+    entries: new Map(),
+    head,
+    tail,
+    currentBytes: 0,
+    maxByteSize: options.maxByteSize,
+    cacheDir: options.cacheDir,
+    buildId: options.buildId,
+    warmOnInit: options.warmOnInit,
+    entriesDir: join(options.cacheDir, options.buildId, 'entries'),
+    indexPath: join(options.cacheDir, options.buildId, 'index.json'),
+    persistedKeys: new Set(),
+    keyHashes: new Map(),
+    entriesDirCreated: false,
+    indexDirty: false,
+    indexTimer: undefined,
+    pendingWrites: new Set(),
+    pendingLoads: new Map(),
+    ready: true,
+    deps,
+  };
+
+  state.ready = initFromDisk(state);
+
+  return {
+    async get(key) {
+      await ensureReady(state);
+      const node = state.entries.get(key);
+      if (node) {
+        listMoveToFront(state.head, node);
+        return node.value;
+      }
+      const inflight = state.pendingLoads.get(key);
+      if (inflight) return inflight;
+      if (!state.persistedKeys.has(key)) return undefined;
+      const p = readEntryFromDisk(state, key);
+      state.pendingLoads.set(key, p);
+      return p;
+    },
+
+    async set(key, value) {
+      await ensureReady(state);
+      const size = value.body.byteLength;
+      if (size > state.maxByteSize) return;
+
+      const existing = state.entries.get(key);
+      if (existing) {
+        existing.value = value;
+        state.currentBytes = state.currentBytes - existing.size + size;
+        existing.size = size;
+        listMoveToFront(state.head, existing);
+      } else {
+        const node = createListEntry(key, value, size);
+        state.entries.set(key, node);
+        listInsertFront(state.head, node);
+        state.currentBytes += size;
+      }
+
+      evictUntilUnderBudget(state);
+
+      state.persistedKeys.add(key);
+      trackWrite(
+        state,
+        writeEntryToDisk(state, key, value).catch(() => {}),
+      );
+    },
+
+    async delete(key) {
+      await ensureReady(state);
+      const node = state.entries.get(key);
+      if (node) {
+        listDetach(node);
+        state.entries.delete(key);
+        state.currentBytes -= node.size;
+      }
+      if (state.persistedKeys.has(key)) {
+        trackWrite(
+          state,
+          removeEntryFromDisk(state, key).catch(() => {}),
+        );
+      }
+    },
+
+    get keys() {
+      return state.persistedKeys as ReadonlySet<string>;
+    },
+
+    async save() {
+      await Promise.all(state.pendingWrites);
+      clearIndexTimer(state);
+      await writeIndex(state);
+    },
+
+    async destroy() {
+      await Promise.all(state.pendingWrites);
+      clearIndexTimer(state);
+      await writeIndex(state).catch(() => {});
+    },
+  };
+}
+
+// ─── Test-only exports ────────────────────────────────────────────────────
+
+/** @internal Exposed only for unit tests. Do not use. */
+export const __test__ = {
+  createListSentinel,
+  createListEntry,
+  listInsertFront,
+  listDetach,
+  listMoveToFront,
+  encodeEntry,
+  decodeEntry,
+};

--- a/packages/astro-bun/src/compression/compression.test.ts
+++ b/packages/astro-bun/src/compression/compression.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { brotliDecompressSync, gunzipSync } from 'node:zlib';
+import { COMPRESSIBLE_EXTENSIONS, compressStaticAssets } from './index.ts';
+import { resolveCompressed } from './serve.ts';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'astro-bun-compression-'));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('Compression', () => {
+  describe('Extensions', () => {
+    test('exports a list of compressible extensions', () => {
+      expect(COMPRESSIBLE_EXTENSIONS).toEqual([
+        '.css',
+        '.js',
+        '.html',
+        '.svg',
+        '.json',
+        '.xml',
+        '.txt',
+        '.mjs',
+      ]);
+    });
+  });
+
+  describe('Static Assets', () => {
+    test('returns zero stats when directory is empty', async () => {
+      const stats = await compressStaticAssets(tmpDir);
+
+      expect(stats.fileCount).toBe(0);
+      expect(stats.bytesSaved).toBe(0);
+    });
+
+    test('compresses a single file with .br and .gz output', async () => {
+      const filePath = join(tmpDir, 'index.html');
+      const content = '<!DOCTYPE html><html><body>Hello, World!</body></html>';
+      await writeFile(filePath, content);
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      const br = await readFile(`${filePath}.br`);
+      const gz = await readFile(`${filePath}.gz`);
+
+      expect(brotliDecompressSync(br).toString()).toBe(content);
+      expect(gunzipSync(gz).toString()).toBe(content);
+      expect(stats.fileCount).toBe(1);
+    });
+
+    test('compresses files for every supported extension', async () => {
+      const files: ReadonlyArray<readonly [string, string]> = [
+        ['style.css', 'body { color: red; }'],
+        ['app.js', 'console.log("hi");'],
+        ['page.html', '<html></html>'],
+        ['icon.svg', '<svg></svg>'],
+        ['data.json', '{"key":"value"}'],
+        ['feed.xml', '<?xml version="1.0"?><root/>'],
+        ['robots.txt', 'User-agent: *'],
+        ['module.mjs', 'export default {};'],
+      ];
+
+      for (const [name, content] of files) {
+        await writeFile(join(tmpDir, name), content);
+      }
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      for (const [name] of files) {
+        expect(await Bun.file(join(tmpDir, `${name}.br`)).exists()).toBe(true);
+        expect(await Bun.file(join(tmpDir, `${name}.gz`)).exists()).toBe(true);
+      }
+
+      expect(stats.fileCount).toBe(files.length);
+    });
+
+    test('skips files with non-compressible extensions', async () => {
+      await writeFile(join(tmpDir, 'image.png'), 'fake png content');
+      await writeFile(join(tmpDir, 'video.mp4'), 'fake mp4 content');
+      await writeFile(join(tmpDir, 'archive.zip'), 'fake zip content');
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      expect(await Bun.file(join(tmpDir, 'image.png.br')).exists()).toBe(false);
+      expect(await Bun.file(join(tmpDir, 'video.mp4.br')).exists()).toBe(false);
+      expect(await Bun.file(join(tmpDir, 'archive.zip.br')).exists()).toBe(
+        false,
+      );
+      expect(stats.fileCount).toBe(0);
+    });
+
+    test('recurses into nested directories', async () => {
+      await mkdir(join(tmpDir, 'sub', 'deeper'), { recursive: true });
+      await writeFile(join(tmpDir, 'top.css'), 'a{}');
+      await writeFile(join(tmpDir, 'sub', 'middle.js'), 'var x = 1;');
+      await writeFile(
+        join(tmpDir, 'sub', 'deeper', 'leaf.html'),
+        '<p>deep</p>',
+      );
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      expect(await Bun.file(join(tmpDir, 'top.css.br')).exists()).toBe(true);
+      expect(await Bun.file(join(tmpDir, 'sub', 'middle.js.br')).exists()).toBe(
+        true,
+      );
+      expect(
+        await Bun.file(join(tmpDir, 'sub', 'deeper', 'leaf.html.br')).exists(),
+      ).toBe(true);
+      expect(stats.fileCount).toBe(3);
+    });
+
+    test('mixes compressible and non-compressible files in the same directory', async () => {
+      await writeFile(join(tmpDir, 'page.html'), '<html></html>');
+      await writeFile(join(tmpDir, 'image.png'), 'binary');
+      await writeFile(join(tmpDir, 'style.css'), 'body{}');
+      await writeFile(join(tmpDir, 'video.webm'), 'binary');
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      expect(await Bun.file(join(tmpDir, 'page.html.br')).exists()).toBe(true);
+      expect(await Bun.file(join(tmpDir, 'style.css.br')).exists()).toBe(true);
+      expect(await Bun.file(join(tmpDir, 'image.png.br')).exists()).toBe(false);
+      expect(await Bun.file(join(tmpDir, 'video.webm.br')).exists()).toBe(
+        false,
+      );
+      expect(stats.fileCount).toBe(2);
+    });
+
+    test('skips non-file entries (e.g. symlinks)', async () => {
+      const targetPath = join(tmpDir, 'target.css');
+      await writeFile(targetPath, 'a{}');
+
+      const linkPath = join(tmpDir, 'link.css');
+      await symlink(targetPath, linkPath);
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      // Real file gets compressed
+      expect(await Bun.file(`${targetPath}.br`).exists()).toBe(true);
+
+      // Symlink is not a regular file, gets skipped
+      expect(await Bun.file(`${linkPath}.br`).exists()).toBe(false);
+      expect(stats.fileCount).toBe(1);
+    });
+
+    test('handles empty files', async () => {
+      const filePath = join(tmpDir, 'empty.css');
+      await writeFile(filePath, '');
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      const br = await readFile(`${filePath}.br`);
+      const gz = await readFile(`${filePath}.gz`);
+
+      expect(brotliDecompressSync(br).toString()).toBe('');
+      expect(gunzipSync(gz).toString()).toBe('');
+      expect(stats.fileCount).toBe(1);
+    });
+
+    test('reports positive bytesSaved for highly compressible content', async () => {
+      // Highly repetitive content compresses well — exercises the bytesSaved
+      // accumulation path with both br and gz being smaller than the original.
+      const content = 'a'.repeat(10_000);
+      await writeFile(join(tmpDir, 'large.txt'), content);
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      expect(stats.bytesSaved).toBeGreaterThan(0);
+    });
+
+    test('reports zero or near-zero bytesSaved for tiny content', async () => {
+      // Tiny content has little compression potential; bytesSaved may be
+      // small or even negative in theory, but we just check it's a number.
+      await writeFile(join(tmpDir, 'tiny.css'), 'a{}');
+
+      const stats = await compressStaticAssets(tmpDir);
+
+      expect(typeof stats.bytesSaved).toBe('number');
+      expect(stats.fileCount).toBe(1);
+    });
+  });
+
+  describe('resolveCompressed', () => {
+    test('returns brotli when client accepts br and .br exists', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+      await writeFile(`${filePath}.br`, 'compressed');
+
+      const result = resolveCompressed(filePath, 'br, gzip, deflate');
+
+      expect(result.encoding).toBe('br');
+      expect(result.path).toBe(`${filePath}.br`);
+    });
+
+    test('returns gzip when client accepts gzip and only .gz exists', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+      await writeFile(`${filePath}.gz`, 'compressed');
+
+      const result = resolveCompressed(filePath, 'gzip, deflate');
+
+      expect(result.encoding).toBe('gzip');
+      expect(result.path).toBe(`${filePath}.gz`);
+    });
+
+    test('prefers brotli over gzip when both are accepted and both exist', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+      await writeFile(`${filePath}.br`, 'br-compressed');
+      await writeFile(`${filePath}.gz`, 'gz-compressed');
+
+      const result = resolveCompressed(filePath, 'br, gzip');
+
+      expect(result.encoding).toBe('br');
+      expect(result.path).toBe(`${filePath}.br`);
+    });
+
+    test('falls back to gzip when client accepts both but only .gz exists', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+      await writeFile(`${filePath}.gz`, 'compressed');
+
+      const result = resolveCompressed(filePath, 'br, gzip');
+
+      expect(result.encoding).toBe('gzip');
+      expect(result.path).toBe(`${filePath}.gz`);
+    });
+
+    test('returns original when client accepts br but .br does not exist', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+
+      const result = resolveCompressed(filePath, 'br');
+
+      expect(result.encoding).toBeNull();
+      expect(result.path).toBe(filePath);
+    });
+
+    test('returns original when client accepts gzip but .gz does not exist', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+
+      const result = resolveCompressed(filePath, 'gzip');
+
+      expect(result.encoding).toBeNull();
+      expect(result.path).toBe(filePath);
+    });
+
+    test('returns original when client accepts neither br nor gzip', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+      await writeFile(`${filePath}.br`, 'compressed');
+      await writeFile(`${filePath}.gz`, 'compressed');
+
+      const result = resolveCompressed(filePath, 'identity');
+
+      expect(result.encoding).toBeNull();
+      expect(result.path).toBe(filePath);
+    });
+
+    test('returns original when accept-encoding is empty', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+      await writeFile(`${filePath}.br`, 'compressed');
+
+      const result = resolveCompressed(filePath, '');
+
+      expect(result.encoding).toBeNull();
+      expect(result.path).toBe(filePath);
+    });
+
+    test('skips br branch when client only accepts gzip, even if .br exists', async () => {
+      const filePath = join(tmpDir, 'app.js');
+      await writeFile(filePath, 'original');
+      await writeFile(`${filePath}.br`, 'br-compressed');
+      await writeFile(`${filePath}.gz`, 'gz-compressed');
+
+      const result = resolveCompressed(filePath, 'gzip');
+
+      expect(result.encoding).toBe('gzip');
+      expect(result.path).toBe(`${filePath}.gz`);
+    });
+  });
+});

--- a/packages/astro-bun/src/compression/index.ts
+++ b/packages/astro-bun/src/compression/index.ts
@@ -1,0 +1,65 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { brotliCompressSync, gzipSync } from 'node:zlib';
+
+export const COMPRESSIBLE_EXTENSIONS = [
+  '.css',
+  '.js',
+  '.html',
+  '.svg',
+  '.json',
+  '.xml',
+  '.txt',
+  '.mjs',
+];
+
+export type CompressionStats = {
+  fileCount: number;
+  bytesSaved: number;
+};
+
+/**
+ * Recursively collect all compressible file paths under a directory.
+ * Filters by `COMPRESSIBLE_EXTENSIONS`.
+ */
+async function walkCompressible(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkCompressible(full)));
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!COMPRESSIBLE_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+      continue;
+    }
+    files.push(full);
+  }
+  return files;
+}
+
+/**
+ * Generate `.br` and `.gz` versions of every compressible file under
+ * `clientDir`. Returns the count of compressed files and total bytes saved
+ * (using whichever variant is smaller per file).
+ */
+export async function compressStaticAssets(
+  clientDir: string,
+): Promise<CompressionStats> {
+  const files = await walkCompressible(clientDir);
+  let bytesSaved = 0;
+
+  for (const file of files) {
+    const content = await readFile(file);
+    const br = brotliCompressSync(content);
+    const gz = gzipSync(content);
+
+    await writeFile(`${file}.br`, br);
+    await writeFile(`${file}.gz`, gz);
+
+    bytesSaved += content.length - Math.min(br.length, gz.length);
+  }
+
+  return { fileCount: files.length, bytesSaved };
+}

--- a/packages/astro-bun/src/compression/serve.ts
+++ b/packages/astro-bun/src/compression/serve.ts
@@ -1,0 +1,22 @@
+import { existsSync } from 'node:fs';
+
+/**
+ * Pick the most preferred pre-compressed variant available on disk.
+ *
+ * Returns the path to the best matching file (`.br`, `.gz`, or original)
+ * and the encoding to set on the `Content-Encoding` response header.
+ */
+export function resolveCompressed(
+  filePath: string,
+  acceptEncoding: string,
+): { path: string; encoding: string | null } {
+  if (acceptEncoding.includes('br')) {
+    const br = `${filePath}.br`;
+    if (existsSync(br)) return { path: br, encoding: 'br' };
+  }
+  if (acceptEncoding.includes('gzip')) {
+    const gz = `${filePath}.gz`;
+    if (existsSync(gz)) return { path: gz, encoding: 'gzip' };
+  }
+  return { path: filePath, encoding: null };
+}

--- a/packages/astro-bun/src/index.ts
+++ b/packages/astro-bun/src/index.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type {
+  AstroAdapter,
+  AstroConfig,
+  AstroIntegration,
+  RouteToHeaders,
+} from 'astro';
+import { compressStaticAssets } from './compression/index.ts';
+import { generateStaticManifest } from './manifest.ts';
+import type { AdapterOptions } from './types.ts';
+
+export type { AdapterOptions } from './types.ts';
+
+const VIRTUAL_MODULE_ID = 'virtual:@scale.digital/astro-bun/config';
+const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
+
+function getAdapter(): AstroAdapter {
+  return {
+    name: '@scale.digital/astro-bun',
+    serverEntrypoint: '@scale.digital/astro-bun/server.js',
+    previewEntrypoint: '@scale.digital/astro-bun/preview',
+    entrypointResolution: 'auto',
+    adapterFeatures: {
+      buildOutput: 'server',
+      edgeMiddleware: false,
+      staticHeaders: true,
+    },
+    supportedAstroFeatures: {
+      hybridOutput: 'stable',
+      staticOutput: 'stable',
+      serverOutput: 'stable',
+      sharpImageService: 'stable',
+      envGetSecret: 'stable',
+    },
+  };
+}
+
+export interface CacheConfig {
+  maxByteSize?: number;
+  cacheDir?: string;
+  warmOnInit?: boolean;
+}
+
+type BunAdapterConfig = {
+  staticCacheControl?: string;
+  cache?: boolean | CacheConfig;
+  compress?: boolean;
+};
+
+export default function bun(
+  adapterConfig?: BunAdapterConfig,
+): AstroIntegration {
+  const staticCacheControl =
+    adapterConfig?.staticCacheControl ??
+    'public, max-age=86400, must-revalidate';
+  const compress = adapterConfig?.compress ?? true;
+
+  let config: AstroConfig | undefined;
+  let command: string | undefined;
+  let adapterDir: string | undefined;
+  let routeToHeaders: RouteToHeaders | undefined;
+  let adapterOptions: AdapterOptions | undefined;
+
+  return {
+    name: '@scale.digital/astro-bun',
+    hooks: {
+      'astro:config:setup': (options) => {
+        command = options.command;
+        const { updateConfig, config: currentConfig } = options;
+        updateConfig({
+          build: {
+            redirects: false,
+          },
+          image: {
+            endpoint: {
+              route: currentConfig.image.endpoint.route ?? '_image',
+              entrypoint:
+                currentConfig.image.endpoint.entrypoint ??
+                (options.command === 'dev'
+                  ? 'astro/assets/endpoint/dev'
+                  : 'astro/assets/endpoint/node'),
+            },
+          },
+          session: {
+            driver: currentConfig.session?.driver ?? 'fs-lite',
+          },
+          vite: {
+            ssr: {
+              ...(options.command !== 'dev' && {
+                noExternal: true,
+                external: ['sharp'],
+              }),
+            },
+            plugins: [
+              {
+                name: '@scale.digital/astro-bun/config',
+                resolveId(id) {
+                  if (id === VIRTUAL_MODULE_ID)
+                    return RESOLVED_VIRTUAL_MODULE_ID;
+                },
+                load(id) {
+                  if (id === RESOLVED_VIRTUAL_MODULE_ID) {
+                    return `export default ${JSON.stringify(adapterOptions ?? {})}`;
+                  }
+                },
+              },
+            ],
+          },
+        });
+      },
+      'astro:config:done': ({ setAdapter, config: doneConfig }) => {
+        config = doneConfig;
+        const isDevMode = command === 'dev';
+        const cacheConfig: CacheConfig =
+          typeof adapterConfig?.cache === 'object' ? adapterConfig.cache : {};
+
+        const relativeAdapterDir = '.astro-bun-adapter';
+        const serverPath = fileURLToPath(new URL(doneConfig.build.server));
+        adapterDir = join(serverPath, relativeAdapterDir);
+
+        adapterOptions = {
+          host: doneConfig.server.host,
+          port: doneConfig.server.port,
+          // Relative paths from the server entrypoint. Resolved at runtime.
+          // Entrypoint lives in dist/server/, client in dist/client/, adapter artifacts in dist/server/.astro-bun-adapter/
+          client: '../client',
+          server: '.',
+          adapterDir: relativeAdapterDir,
+          assets: doneConfig.build.assets,
+          staticCacheControl,
+          imageEndpointRoute: doneConfig.image.endpoint.route.startsWith('/')
+            ? doneConfig.image.endpoint.route
+            : `/${doneConfig.image.endpoint.route}`,
+          cache:
+            !isDevMode && adapterConfig?.cache
+              ? {
+                  maxByteSize: cacheConfig.maxByteSize ?? 50 * 1024 * 1024,
+                  cacheDir: cacheConfig.cacheDir,
+                  warmOnInit: cacheConfig.warmOnInit ?? false,
+                }
+              : false,
+        };
+
+        setAdapter(getAdapter());
+      },
+      'astro:build:generated': ({ routeToHeaders: rth }) => {
+        routeToHeaders = rth;
+      },
+      'astro:build:done': async ({ logger }) => {
+        if (!config || !adapterDir) return;
+
+        const clientDir = new URL(config.build.client, config.outDir);
+        await mkdir(adapterDir, { recursive: true });
+
+        let serializedRouteHeaders:
+          | Record<string, Record<string, string>>
+          | undefined;
+        if (routeToHeaders && routeToHeaders.size > 0) {
+          serializedRouteHeaders = {};
+          for (const [route, payload] of routeToHeaders) {
+            const headers: Record<string, string> = {};
+            payload.headers.forEach((value, key) => {
+              headers[key] = value;
+            });
+            serializedRouteHeaders[route] = headers;
+          }
+        }
+
+        await generateStaticManifest(
+          clientDir.pathname,
+          adapterDir,
+          config.build.assets,
+          serializedRouteHeaders,
+          staticCacheControl,
+        );
+
+        if (compress) {
+          const start = performance.now();
+          const { fileCount, bytesSaved } = await compressStaticAssets(
+            clientDir.pathname,
+          );
+          const elapsed = ((performance.now() - start) / 1000).toFixed(2);
+          const savedKiB = Math.round(bytesSaved / 1024);
+          logger.info(
+            `Compressed ${fileCount} assets (saved ~${savedKiB} KiB) in ${elapsed}s.`,
+          );
+        }
+
+        const buildId = randomUUID();
+        await writeFile(join(adapterDir, 'build-id'), buildId);
+      },
+    },
+  };
+}

--- a/packages/astro-bun/src/manifest.ts
+++ b/packages/astro-bun/src/manifest.ts
@@ -1,0 +1,145 @@
+import { createHash } from 'node:crypto';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { extname, join, relative } from 'node:path';
+import type { ManifestEntry, StaticManifest } from './types.ts';
+
+/** Immutable cache for Vite-hashed assets, configurable for everything else. */
+function getCacheControl(
+  pathname: string,
+  assetsPrefix: string,
+  staticCacheControl: string,
+): string {
+  if (pathname.startsWith(`/${assetsPrefix}/`)) {
+    return 'public, max-age=31536000, immutable';
+  }
+  return staticCacheControl;
+}
+
+/** Recursively collect all file paths under a directory. */
+async function walk(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  const tasks: Promise<string[]>[] = [];
+
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      tasks.push(walk(full));
+    } else if (entry.isFile()) {
+      files.push(full);
+    }
+  }
+
+  const nested = await Promise.all(tasks);
+  for (const list of nested) {
+    for (const f of list) files.push(f);
+  }
+
+  return files;
+}
+
+/**
+ * Derive the route pathname from a static file path.
+ * `/about/index.html` → `/about`, `/index.html` → `/`, `/about.html` → `/about`
+ */
+function filePathToRoute(filePath: string): string {
+  if (filePath.endsWith('/index.html')) {
+    const route = filePath.slice(0, -'/index.html'.length);
+    return route || '/';
+  }
+  if (filePath.endsWith('.html')) {
+    return filePath.slice(0, -'.html'.length);
+  }
+  return filePath;
+}
+
+/** Infer MIME type from a file path using Bun's built-in detection. */
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.mjs': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.xml': 'application/xml',
+  '.txt': 'text/plain',
+  '.webmanifest': 'application/manifest+json',
+  '.pdf': 'application/pdf',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+};
+
+function getMimeType(filePath: string): string | undefined {
+  return MIME_TYPES[extname(filePath)];
+}
+
+/**
+ * Walk the client build directory and write a static manifest with
+ * pre-computed headers for each file (ETag, Content-Type, Cache-Control).
+ */
+export async function generateStaticManifest(
+  clientDir: string,
+  outDir: string,
+  assetsPrefix: string,
+  routeHeaders: Record<string, Record<string, string>> | undefined,
+  staticCacheControl: string,
+): Promise<void> {
+  const files = await walk(clientDir);
+  const manifest: StaticManifest = {};
+
+  const entries = await Promise.all(
+    files.map(async (filePath) => {
+      const content = await readFile(filePath);
+      const hash = createHash('sha256')
+        .update(content)
+        .digest('hex')
+        .slice(0, 16);
+
+      const pathname = `/${relative(clientDir, filePath)}`;
+      const contentType = getMimeType(filePath);
+      const headers: Record<string, string> = {
+        'Cache-Control': getCacheControl(
+          pathname,
+          assetsPrefix,
+          staticCacheControl,
+        ),
+        ...routeHeaders?.[filePathToRoute(pathname)],
+        ETag: `"${hash}"`,
+        'Content-Length': String(content.byteLength),
+      };
+      if (contentType) headers['Content-Type'] = contentType;
+
+      const entry: ManifestEntry = {
+        headers,
+        filePath: relative(clientDir, filePath),
+      };
+      return [pathname, entry] as const;
+    }),
+  );
+
+  for (const [pathname, entry] of entries) {
+    manifest[pathname] = entry;
+
+    // Route alias: `/about/index.html` also serves under `/about`
+    const route = filePathToRoute(pathname);
+    if (route !== pathname) {
+      manifest[route] = { ...entry, filePath: pathname.slice(1) };
+    }
+  }
+
+  await writeFile(
+    join(outDir, 'static-manifest.json'),
+    JSON.stringify(manifest),
+  );
+}

--- a/packages/astro-bun/src/paths.ts
+++ b/packages/astro-bun/src/paths.ts
@@ -1,0 +1,25 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const ADAPTER_DIR_NAME = '.astro-bun-adapter';
+const MAX_LOOKUP_DEPTH = 5;
+
+/**
+ * Walk up the directory tree from `start` looking for the adapter
+ * artifacts directory (`.astro-bun-adapter`). The directory is written
+ * by the build hook and contains the static manifest, build id, and
+ * (optionally) the cache index.
+ *
+ * Throws if not found within `MAX_LOOKUP_DEPTH` parent directories.
+ */
+export function findAdapterDir(start: string): string {
+  let dir = start;
+  for (let i = 0; i < MAX_LOOKUP_DEPTH; i++) {
+    const candidate = join(dir, ADAPTER_DIR_NAME);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`Could not find ${ADAPTER_DIR_NAME} from ${start}`);
+}

--- a/packages/astro-bun/src/preview.ts
+++ b/packages/astro-bun/src/preview.ts
@@ -1,0 +1,33 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CreatePreviewServer } from 'astro';
+
+const preview: CreatePreviewServer = async ({
+  serverEntrypoint,
+  host,
+  port,
+}) => {
+  const serverDir = dirname(fileURLToPath(serverEntrypoint));
+  const targetHost = host ?? 'localhost';
+  const targetPort = port ?? 4321;
+
+  const proc = Bun.spawn(['bun', 'run', join(serverDir, 'index.mjs')], {
+    env: { ...process.env, HOST: targetHost, PORT: String(targetPort) },
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+
+  return {
+    host: targetHost,
+    port: targetPort,
+    stop() {
+      proc.kill();
+      return Promise.resolve();
+    },
+    closed() {
+      return proc.exited.then(() => {});
+    },
+  };
+};
+
+export default preview;

--- a/packages/astro-bun/src/server.ts
+++ b/packages/astro-bun/src/server.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import options from 'virtual:@scale.digital/astro-bun/config';
+import { createApp } from 'astro/app/entrypoint';
+import { setGetEnv } from 'astro/env/setup';
+import { registerCache } from './cache';
+import { buildImageCacheKey } from './cache/images.ts';
+import { createCacheServer } from './cache/serve.ts';
+import { resolveCompressed } from './compression/serve.ts';
+import { findAdapterDir } from './paths.ts';
+import type { AdapterOptions, CacheServer, ManifestEntry } from './types.ts';
+
+const CACHE_HEADER = 'x-astro-cache';
+
+setGetEnv((key) => process.env[key]);
+
+// --- Auto-start ---
+const config = options as AdapterOptions;
+const app = createApp();
+const logger = app.getAdapterLogger();
+
+const ssrHandler = async (request: Request): Promise<Response> => {
+  const routeData = app.match(request);
+  if (!routeData) {
+    return app.render(request, { addCookieHeader: true });
+  }
+  return app.render(request, { addCookieHeader: true, routeData });
+};
+
+// Resolve paths at runtime relative to this entrypoint file.
+// Config values are relative paths from the server entrypoint's location.
+const entryDir = dirname(fileURLToPath(import.meta.url));
+const adapterDir = findAdapterDir(entryDir);
+const clientDir = resolve(dirname(adapterDir), '..', 'client');
+
+const staticManifest = new Map<string, ManifestEntry>(
+  Object.entries(
+    JSON.parse(readFileSync(join(adapterDir, 'static-manifest.json'), 'utf-8')),
+  ),
+);
+
+let cacheServer: CacheServer | undefined;
+if (config.cache) {
+  const buildId = readFileSync(join(adapterDir, 'build-id'), 'utf-8').trim();
+  const cacheDir = config.cache.cacheDir ?? join(adapterDir, 'cache');
+  cacheServer = createCacheServer({
+    origin: ssrHandler,
+    maxByteSize: config.cache.maxByteSize,
+    cacheDir,
+    buildId,
+    warmOnInit: config.cache.warmOnInit,
+    imageEndpointRoute: config.imageEndpointRoute,
+  });
+  registerCache(cacheServer.cache);
+}
+
+if (cacheServer) {
+  const shutdown = () => {
+    cacheServer
+      ?.shutdown()
+      .catch((err: unknown) => console.error('Cache flush failed:', err))
+      .finally(() => process.exit(0));
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+const port = Number(process.env.PORT || config.port || 4321);
+const host =
+  process.env.HOST ??
+  (typeof config.host === 'boolean'
+    ? config.host
+      ? '0.0.0.0'
+      : 'localhost'
+    : config.host);
+
+export const server = Bun.serve({
+  port,
+  hostname: host,
+  async fetch(request) {
+    const url = new URL(request.url);
+    const pathname = decodeURIComponent(url.pathname);
+    const acceptEncoding = request.headers.get('accept-encoding') ?? '';
+
+    if (request.method === 'GET' || request.method === 'HEAD') {
+      const meta = staticManifest.get(pathname);
+      if (meta) {
+        const headers = new Headers(meta.headers);
+        headers.set(CACHE_HEADER, 'STATIC');
+
+        if (request.headers.get('if-none-match') === meta.headers.ETag) {
+          headers.delete('Content-Length');
+          headers.delete('Content-Type');
+          return new Response(null, { status: 304, headers });
+        }
+
+        const fullPath = join(clientDir, meta.filePath);
+        const { path: servePath, encoding } = resolveCompressed(
+          fullPath,
+          acceptEncoding,
+        );
+
+        if (encoding) {
+          headers.set('Content-Encoding', encoding);
+          headers.delete('Content-Length');
+        }
+        headers.set('Vary', 'Accept-Encoding');
+
+        return new Response(Bun.file(servePath), {
+          status: 200,
+          headers,
+        });
+      }
+
+      const file = Bun.file(join(clientDir, pathname));
+      if (await file.exists()) {
+        const fullPath = join(clientDir, pathname);
+        const { path: servePath, encoding } = resolveCompressed(
+          fullPath,
+          acceptEncoding,
+        );
+
+        const headers = new Headers();
+        if (encoding) {
+          headers.set('Content-Encoding', encoding);
+          headers.set('Vary', 'Accept-Encoding');
+        }
+
+        return new Response(Bun.file(servePath), { headers });
+      }
+    }
+
+    if (!cacheServer || request.method !== 'GET') {
+      const response = await ssrHandler(request);
+      response.headers.set(CACHE_HEADER, 'BYPASS');
+      return response;
+    }
+
+    const cacheKey = pathname.startsWith(config.imageEndpointRoute)
+      ? buildImageCacheKey(pathname, url.searchParams)
+      : pathname;
+    return cacheServer(request, cacheKey);
+  },
+});
+
+logger.info(`Server listening on http://${host}:${port}`);

--- a/packages/astro-bun/src/types.ts
+++ b/packages/astro-bun/src/types.ts
@@ -1,0 +1,62 @@
+/** Build-time configuration passed to the server entrypoint via virtual module. */
+export type AdapterOptions = {
+  /** Hostname or boolean (`true` = `"0.0.0.0"`, `false` = `"localhost"`). */
+  host: string | boolean;
+  /** Port the server listens on. */
+  port: number;
+  /** Absolute `file://` URL to `dist/client/`. */
+  client: string;
+  /** Absolute `file://` URL to `dist/server/`. */
+  server: string;
+  /** Relative path to adapter directory within `dist/server/`. */
+  adapterDir: string;
+  /** Name of the assets directory (default `_astro`). */
+  assets: string;
+  /** `Cache-Control` header for non-hashed static assets. */
+  staticCacheControl: string;
+  /** Image endpoint route with leading slash (e.g. `"/_image"`). */
+  imageEndpointRoute: string;
+  /** Cache configuration. `false` disables caching. */
+  cache: false | CacheOptions;
+};
+
+/** Resolved cache configuration. */
+export type CacheOptions = {
+  maxByteSize: number;
+  cacheDir?: string;
+  warmOnInit: boolean;
+};
+
+/** A cached SSR response with timing metadata for fresh/stale/expired checks. */
+export type CacheEntry = {
+  body: Uint8Array;
+  headers: [string, string][];
+  status: number;
+  cachedAt: number;
+  /** `s-maxage` in seconds — defines the fresh window. */
+  sMaxAge: number;
+  /** `stale-while-revalidate` in seconds — defines the stale window. */
+  swr: number;
+};
+
+/** Pre-computed response headers for a static file. */
+export type ManifestEntry = {
+  headers: Record<string, string>;
+  /** Relative file path within client dir. */
+  filePath: string;
+};
+
+export type StaticManifest = Record<string, ManifestEntry>;
+
+/** Minimal control surface for on-demand cache expiration. */
+export type CacheControl = {
+  expire: (key: string) => Promise<void>;
+  expireAll: () => Promise<void>;
+};
+
+/** Caching request handler with shutdown and on-demand expiration. */
+export type CacheServer = {
+  (request: Request, cacheKey: string): Promise<Response>;
+  shutdown: () => Promise<void>;
+  cache: CacheControl;
+};

--- a/packages/astro-bun/src/virtual.d.ts
+++ b/packages/astro-bun/src/virtual.d.ts
@@ -1,0 +1,7 @@
+// src/virtual.d.ts
+declare module 'virtual:@scale.digital/astro-bun/config' {
+  import type { AdapterOptions } from './types';
+
+  const options: AdapterOptions;
+  export default options;
+}

--- a/packages/astro-bun/tsconfig.build.json
+++ b/packages/astro-bun/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/index.ts", "src/cache"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/astro-bun/tsconfig.json
+++ b/packages/astro-bun/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "types": ["bun", "node"],
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}

--- a/tools/pre-commit.nix
+++ b/tools/pre-commit.nix
@@ -7,7 +7,15 @@ _: {
   # Generic file checks
   check-yaml.enable = true;
   check-toml.enable = true;
-  check-json.enable = true;
+
+  check-json = {
+    enable = true;
+    excludes = [
+      "tsconfig\\.json$"
+      "tsconfig\\..*\\.json$"
+    ];
+  };
+
   check-merge-conflicts.enable = true;
   end-of-file-fixer.enable = true;
   trim-trailing-whitespace.enable = true;


### PR DESCRIPTION
## Summary

Adds the `@scale.digital/astro-bun` package — a Bun-native Astro 6 adapter.

## What's included

- Astro integration hooks (`astro:config:setup`, `astro:config:done`, `astro:build:done`)
- Bun.serve runtime with static manifest + ETag/304 caching
- ISR cache layer with LRU + disk persistence (SWR semantics, image-endpoint override)
- Build-time Brotli + gzip pre-compression
- `unstable_expirePath` / `unstable_expireAll` cache invalidation API
- 100% test coverage on testable modules (113 tests)

## Attribution

Based on [`@wyattjoh/astro-bun-adapter`](https://github.com/wyattjoh/astro-bun-adapter) (MIT).
LICENSE includes both BSD-3 (this work) and MIT (upstream attribution).

## Validated against

- astro 6.2.0
- @qwik.dev/astro 1.0.1
- @qwik.dev/core 2.0.0-beta.32
- bun 1.3.11

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #




