### PR TITLE
fix(astro-bun): sync version with published npm seed (0.0.0)

### DIFF
--- a/packages/astro-bun/package.json
+++ b/packages/astro-bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scale.digital/astro-bun",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "A native Bun adapter for Astro 6 — runs SSR, hybrid, and static sites directly on Bun.serve",
   "keywords": [
     "astro",


### PR DESCRIPTION
## Summary

Restores `package.json` version to `0.0.0` to match the manually published npm seed. The previous `0.0.1` value caused the release workflow to attempt republishing an unpublished version, which npm permanently rejects.

The version was changed locally for the manual seed publish but the change wasn't committed to main.

## Changes

- Set `packages/astro-bun/package.json` version from `0.0.1` to `0.0.0`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
