### PR TITLE
chore: enter prerelease mode and add initial changeset

### DIFF
--- a/.changeset/dark-coins-tan.md
+++ b/.changeset/dark-coins-tan.md
@@ -1,0 +1,5 @@
+---
+"@scale.digital/astro-bun": minor
+---
+
+Initial release of the Bun-native Astro 6 adapter

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@scale.digital/astro-bun": "0.0.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
## Summary

Enters prerelease mode (`rc` tag) and adds the initial changeset for testing the release pipeline before stable 0.1.0.

## Changes

- Add `.changeset/pre.json` to enter prerelease mode with `rc` tag
- Add changeset for minor version bump (0.0.0 → 0.1.0-rc.0)

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
