### PR TITLE
fix(ci): trigger check workflow on changeset-release branches

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,6 +3,9 @@ name: Pull Request
 on:
   pull_request:
     branches: [main]
+  push:
+    branches:
+      - 'changeset-release/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Fixes the Check workflow for Changesets release branches so required status checks are available on Changesets bot PRs.

## Changes

- Add `push` trigger for `changeset-release/**` branches so Changesets bot commits run the required CI check

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
