### PR TITLE
fix(ci): use GitHub App token so bot PRs trigger required checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,18 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
@@ -44,5 +52,5 @@ jobs:
           commit: "chore: release packages"
           title: "chore: release packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

Switches the release workflow to use a GitHub App installation token instead of the default `GITHUB_TOKEN`. This ensures Changesets bot push and PR events trigger required status checks normally.

## Changes

- Add `actions/create-github-app-token` step to generate an installation access token
- Use the App token for `actions/checkout` to enable proper event triggering
- Use the App token in the Changesets action env

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [x] Linked issue (if applicable): #13
