### PR TITLE
Revert "fix(ci): trigger check workflow on changeset-release branches"

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,9 +3,6 @@ name: Pull Request
 on:
   pull_request:
     branches: [main]
-  push:
-    branches:
-      - 'changeset-release/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Reverts ScaliirDigital/root#12

The previous fix added a `push` trigger for `changeset-release/**` branches, but this did not address the root cause reliably and now causes the Check workflow to run twice after the proper fix in #14.

The issue is now handled via #14, so the extra release-branch push trigger is no longer needed.