### PR TITLE
fix(ci): ignore changesets directory in biome checks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**/*.{ts,tsx,js,jsx,json,html,css,astro}"]
+    "includes": ["**/*.{ts,tsx,js,jsx,json,html,css,astro}", "!.changeset"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Exclude `.changeset/` from Biome checks so Changesets-generated release files do not fail CI validation.

## Changes

- Add `!.changeset` to the Biome `files.includes` list

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #