### PR TITLE
fix(astro-bun): add publishConfig for public access

### DIFF
--- a/packages/astro-bun/package.json
+++ b/packages/astro-bun/package.json
@@ -49,6 +49,9 @@
   "engines": {
     "bun": ">=1.3.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "bun build ./src/index.ts ./src/server.ts ./src/preview.ts ./src/cache --outdir ./dist --target bun --external 'virtual:@scale.digital/astro-bun/config' --external astro",
     "types": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
## Summary

Fixes the release workflow failing with E404 when publishing scoped packages to npm.

## Changes

- Add `publishConfig.access: public` to `packages/astro-bun/package.json`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
