### PR TITLE
fix(ci): upgrade Node to 24 so npm trusted publishing works

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Fixes the release workflow failing with E404 on npm publish by upgrading Node.js to 24, which ships with npm 11.x. npm Trusted Publishing requires npm CLI 11.5.1 or later.

## Changes

- Bump `actions/setup-node` from Node 22 to Node 24 in the release workflow

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
