### PR TITLE
fix(ci): use client-id instead of deprecated app-id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout


### PR DESCRIPTION
## Summary

Replaces the deprecated `app-id` input with `client-id` in `actions/create-github-app-token` to remove the deprecation warning.

## Changes

- Use `client-id` input with the new `APP_CLIENT_ID` secret instead of `app-id`/`APP_ID`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
