### PR TITLE
fix(ci): exclude changesets directory from biome pre-commit hook

### DIFF
--- a/tools/pre-commit.nix
+++ b/tools/pre-commit.nix
@@ -27,6 +27,7 @@ _: {
   # Web
   biome = {
     enable = true;
+    excludes = ["^\\.changeset/.*"];
     types_or = [
       "javascript"
       "jsx"


### PR DESCRIPTION
## Summary

Fixes the pre-commit hook failing when Changesets-related files are part of a commit.

## Changes

- Add `excludes = ["^\\.changeset/.*"]` to the Biome pre-commit hook config

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
