### PR TITLE
chore: exit prerelease mode for stable 0.1.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@scale.digital/astro-bun": "0.0.0"


### PR DESCRIPTION
## Summary

Exits Changesets prerelease mode in preparation for the first stable `0.1.0` release.

## Changes

- Remove `.changeset/pre.json` to exit `rc` prerelease mode

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
