### PR TITLE
ci: stage pull_request_target trigger for fork PR support

### DIFF
--- a/.github/workflows/pull_request_test.yaml
+++ b/.github/workflows/pull_request_test.yaml
@@ -1,0 +1,24 @@
+name: Pull Request
+
+on:
+  pull_request_target:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  flake-check:
+    name: Check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: >- # https://github.com/actions/checkout/releases/tag/v6.0.2
+          actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Nix
+        uses: >- # https://github.com/DeterminateSystems/nix-installer-action/releases/tag/v22
+          DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25
+
+      - name: Run flake check
+        run: nix flake check --print-build-logs


### PR DESCRIPTION
## Summary

Adds a staged copy of the PR workflow using `pull_request_target` so it can be tested before replacing the active workflow. Required for auto-labeling on fork PRs — the standard `pull_request` event provides only read-only tokens for forks, blocking labeler write access.

## Changes

- Add `.github/workflows/pull_request_test.yaml` mirroring the current `pull_request.yaml` but triggered on `pull_request_target`
- File is intentionally named `_test` — will be renamed to replace the original in a follow-up PR after the full feature lands

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #