### PR TITLE
ci: refine label classification for github meta files

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -14,13 +14,16 @@
 "area: ci":
   - changed-files:
       - any-glob-to-any-file:
-          - '.github/**'
+          - '.github/workflows/**'
+          - '.github/labeler.yaml'
 
 "area: docs":
   - changed-files:
       - any-glob-to-any-file:
           - '**/*.md'
           - '**/*.mdx'
+      - all-globs-to-all-files:
+          - '!.github/**'
 
 "area: chore":
   - changed-files:
@@ -30,3 +33,11 @@
           - '!.github/**'
           - '!**/*.md'
           - '!**/*.mdx'
+
+"area: github":
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+      - all-globs-to-all-files:
+          - '!.github/workflows/**'
+          - '!.github/labeler.yaml'


### PR DESCRIPTION
## Summary

Refines the labeler configuration so GitHub meta files (issue templates, dependabot, etc.) get a dedicated `area: github` label instead of being miscategorized as `area: ci` or `area: docs`. Triggered by observing miscategorized labels on a recent issue template change.

## Changes

- Narrow `area: ci` in `.github/labeler.yaml` to actual CI files (`.github/workflows/**`, `.github/labeler.yaml`)
- Narrow `area: docs` to exclude anything under `.github/`
- Add `area: github` as a catch-all for `.github/` meta files outside of CI
- Add `area: github` label creation to `create-labels.sh`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #