### PR TITLE
chore: exclude examples from Biome includes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,11 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**/*.{ts,tsx,js,jsx,json,html,css,astro}", "!.changeset"]
+    "includes": [
+      "**/*.{ts,tsx,js,jsx,json,html,css,astro}",
+      "!.changeset",
+      "!examples"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Adds `!examples` to Biome's `includes` so the formatter and linter skip the `examples/` directory.

## Changes

- Update `biome.json` `includes` to exclude `examples`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #