### PR TITLE
ci: grant contents:read to Stage 3 Test caller for reusable workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,8 @@ jobs:
   Test:
     needs: resolve
     if: needs.resolve.outputs.astro-bun == 'true'
+    permissions:
+      contents: read
     uses: ./.github/workflows/test-package.yaml
     with:
       package: astro-bun


### PR DESCRIPTION
## Summary

Fixes an invalid workflow error in Stage 3 by granting the `Test` caller job the `contents: read` permission required to call the `test-package.yaml` reusable workflow.

## Changes

- Add `permissions: contents: read` to the `Test` caller job in Stage 3 so the nested reusable workflow can request the same scope (GitHub disallows reusable workflows requesting permissions broader than their caller)

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #