### PR TITLE
ci: scope app token to minimum required permissions

### DIFF
--- a/.github/workflows/ready.yaml
+++ b/.github/workflows/ready.yaml
@@ -30,6 +30,9 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-pull-requests: write
+          permission-statuses: write
 
       - name: Add ready-for-review label
         uses: >- # https://github.com/actions/github-script/releases/tag/v9.0.0


### PR DESCRIPTION
## Summary

Explicitly scopes the GitHub App token used in Stage 2 and Stage 4 to the minimum permissions required for each workflow, instead of inheriting the full set of installed app permissions.

## Changes

- Add `permission-issues: write`, `permission-pull-requests: write`, and `permission-statuses: write` to the `Generate App Token` step so the token only carries the scopes actually needed for labeling, PR edits, and commit status reporting

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #