### PR TITLE
ci: rename unlock workflow to avoid self-trigger

### DIFF
--- a/.github/workflows/unlock.yaml
+++ b/.github/workflows/unlock.yaml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Unlock
 
 on:
   workflow_run:
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   ready:
-    name: Ready
+    name: Pull Request
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Summary

Renames the `unlock` workflow to break a self-trigger loop where the workflow listened for itself via `workflow_run`.

## Changes

- Rename workflow `Pull Request` → `Unlock` in `unlock.yaml`; the `workflow_run` trigger continues to listen for the `Pull Request` workflow defined in `pull_request.yaml`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #