### PR TITLE
ci: simplify and tighten labeler rules

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -27,20 +27,16 @@
       - any-glob-to-any-file:
           - '**/*.md'
           - '**/*.mdx'
-      - all-globs-to-all-files:
-          - '!.github/**'
-          - '!examples/**'
 
 "topic: governance":
   - changed-files:
       - any-glob-to-any-file:
-          - '.github/**'
+          - '.github/ISSUE_TEMPLATE/**'
+          - '.github/PULL_REQUEST_TEMPLATE**'
+          - '.github/CONTRIBUTING.md'
           - '**/LICENSE'
           - '**/LICENSE.*'
           - 'LICENSE'
-      - all-globs-to-all-files:
-          - '!.github/workflows/**'
-          - '!.github/labeler.yaml'
 
 "topic: repository":
   - changed-files:


### PR DESCRIPTION
## Summary

Fixes false-positive labels on root-level config changes (e.g. `biome.json` getting `topic: docs` and `topic: governance` simultaneously).

## Changes

- Simplify `topic: docs` to match any markdown file without exclusions; CONTRIBUTING.md and similar will correctly receive both `topic: docs` and `topic: governance` 
- Replace `topic: governance` negative definition with explicit list of governance files (ISSUE/PR templates, CONTRIBUTING,  LICENSE)

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #