### PR TITLE
ci: fix labeler rules for examples, repository

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -27,6 +27,7 @@
       - any-glob-to-any-file:
           - '**/*.md'
           - '**/*.mdx'
+          - '!examples/**'
 
 "topic: governance":
   - changed-files:
@@ -41,6 +42,7 @@
 "topic: repository":
   - changed-files:
       - all-globs-to-all-files:
+          - 'tools/**'
           - '!packages/**'
           - '!examples/**'
           - '!.github/**'


### PR DESCRIPTION
## Summary

Fix false-positive auto-labeling rules for example projects and repository-level changes.

## Changes

Update labeler.yaml to include `tools/**`for repository labels
Prevent example-specific changes from triggering unrelated docs labels

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #

