### PR TITLE
ci: fix PR workflow names

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -26,12 +26,12 @@ jobs:
         run: nix flake check --print-build-logs
 
   detect:
-    name: Detect
+    name: Detect Changes
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read
     outputs:
-      packages: ${{ steps.filter.outputs.changes }}
+      packages: ${{ steps.resolve.outputs.packages }}
     steps:
       - uses: >- # https://github.com/dorny/paths-filter/releases/tag/v4.0.1
           dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
@@ -41,10 +41,18 @@ jobs:
             astro-bun:
               - 'packages/astro-bun/**'
 
+      - id: resolve
+        name: Resolve test plan
+        run: |
+          if [ '${{ steps.filter.outputs.changes }}' = '[]' ]; then
+            echo 'packages=["none"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'packages=${{ steps.filter.outputs.changes }}' >> "$GITHUB_OUTPUT"
+          fi
+
   test:
-    name: Test / ${{ matrix.package }}
+    name: ${{ matrix.package == 'none' && 'Nothing to test' || format('Tests / {0}', matrix.package) }}
     needs: detect
-    if: needs.detect.outputs.packages != '[]'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -53,20 +61,28 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.detect.outputs.packages) }}
     steps:
+      - name: No package tests required
+        if: matrix.package == 'none'
+        run: echo "No package tests required."
+
       - uses: >- # https://github.com/actions/checkout/releases/tag/v6.0.2
           actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        if: matrix.package != 'none'
         with:
           persist-credentials: false
 
       - name: Setup Bun
+        if: matrix.package != 'none'
         uses: >- # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
           oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: '1.3.13'
 
       - name: Install dependencies
+        if: matrix.package != 'none'
         run: bun install --frozen-lockfile
 
       - name: Run tests
+        if: matrix.package != 'none'
         run: bun test
         working-directory: packages/${{ matrix.package }}


### PR DESCRIPTION
## Summary

Fix PR workflow check names so package test jobs render cleanly for both changed and unchanged package paths.

## Changes

- Resolve package test targets directly in the detect job
- Add a `none` fallback matrix entry when no package-specific tests are required
- Render `Nothing to test` for PRs without package-specific test changes
- Preserve dynamic check names such as `Tests / astro-bun` when package tests run

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #