### PR TITLE
ci: fix docs labeler false positives

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -25,9 +25,10 @@
 "topic: docs":
   - changed-files:
       - any-glob-to-any-file:
-          - '**/*.md'
-          - '**/*.mdx'
-          - '!examples/**'
+          - '*.md'
+          - '*.mdx'
+          - 'packages/**/*.md'
+          - 'packages/**/*.mdx'
 
 "topic: governance":
   - changed-files:


### PR DESCRIPTION
## Summary

Fix docs auto-labeling so workflow-only changes do not incorrectly receive the `topic: docs` label.

## Changes

- Remove negated glob patterns from the docs label rule
- Restrict docs labeling to root-level Markdown files and package Markdown files
- Prevent `.github/**` workflow changes from matching the docs label

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #