### PR TITLE
chore(checks): add convco for conventional commit validation

### DIFF
--- a/tools/pre-commit.nix
+++ b/tools/pre-commit.nix
@@ -24,6 +24,9 @@ _: {
     args = ["--maxkb=1000"];
   };
 
+  # Commit message
+  convco.enable = true;
+
   # Web
   biome = {
     enable = true;


### PR DESCRIPTION
## Summary

Adds `convco` as a pre-commit hook to validate commit messages against the Conventional Commits spec.

## Changes 

-  Enabled convco hook in `tools/pre-commit.nix`

## Checklist

- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #
