### PR TITLE
fix(astro-bun): support Astro 6.3+

### DIFF
--- a/.changeset/mighty-loops-read.md
+++ b/.changeset/mighty-loops-read.md
@@ -1,0 +1,5 @@
+---
+"@scale.digital/astro-bun": patch
+---
+
+Support Astro 6.3+: use `app.adapterLogger` getter, bump peer to `^6.3.0`.

--- a/packages/astro-bun/README.md
+++ b/packages/astro-bun/README.md
@@ -6,11 +6,11 @@ A native Bun adapter for Astro 6 — runs SSR, hybrid, and static sites directly
 >
 > This adapter is in active development and is used in production by Scaliir Digital.
 >
-> Currently validated with Astro 6.2.0 using the Qwik Astro integration:
+> Currently validated with Astro 6.3.7 using the Qwik Astro integration:
 >
-> - `astro` 6.2.0
+> - `astro` 6.3.7
 > - `@qwik.dev/astro` 1.0.1
-> - `@qwik.dev/core` 2.0.0-beta.32
+> - `@qwik.dev/core` 2.0.0-beta.35
 >
 > Other Astro setups may work, but have not been validated yet.
 > The public API may change in minor versions until 1.0.
@@ -30,7 +30,7 @@ bun add @scale.digital/astro-bun
 
 Requirements:
 
-- Astro `^6.0.0`
+- Astro `^6.3.0`
 - Bun `>=1.3.0`
 
 Astro itself uses Node tooling at build time. Node `>=22.12` is required for `astro build`. The runtime is Bun-only.

--- a/packages/astro-bun/package.json
+++ b/packages/astro-bun/package.json
@@ -58,7 +58,7 @@
     "prepack": "bun run build && bun run types"
   },
   "peerDependencies": {
-    "astro": "^6.2.1"
+    "astro": "^6.3.0"
   },
   "devDependencies": {
     "@types/bun": "1.3.13",

--- a/packages/astro-bun/src/server.ts
+++ b/packages/astro-bun/src/server.ts
@@ -17,8 +17,11 @@ setGetEnv((key) => process.env[key]);
 
 // --- Auto-start ---
 const config = options as AdapterOptions;
+
+// Astro 6: createApp() loads the manifest
+// internally via the build-emitted entrypoint.
 const app = createApp();
-const logger = app.getAdapterLogger();
+const logger = app.adapterLogger;
 
 const ssrHandler = async (request: Request): Promise<Response> => {
   const routeData = app.match(request);
@@ -145,3 +148,8 @@ export const server = Bun.serve({
 });
 
 logger.info(`Server listening on http://${host}:${port}`);
+// Suppress noisy "Internal Warning: route cache overwritten" — upstream Astro
+// bug where the route cache is re-set on every SSR request for dynamic routes.
+// We can't filter just that one message via the logger API, so we drop the
+// log level to 'error' after our own startup info is printed.
+logger.options.level = 'error';


### PR DESCRIPTION
## Summary
Patches `@scale.digital/astro-bun` for Astro 6.3+ runtime compatibility and bumps the peer-dependency range accordingly.

## Changes
- Migrate adapter logger access from `app.getAdapterLogger()` method to `app.adapterLogger` getter (Astro 6.3 `BaseApp` refactor)
- Bump `peerDependencies.astro` from `^6.2.1` to `^6.3.0`
- Suppress upstream `Internal Warning: route cache overwritten` emitted on every SSR request for dynamic routes
- Update README status block and requirements to reflect Astro 6.3.7 validation
- Add changeset (patch)

## Checklist
- [x] Single-purpose PR (one concern, one PR)
- [ ] Linked issue (if applicable): #